### PR TITLE
feat(#26): bot-dish-limit-5 (bot dish 상한 보장 및 상수 단일화)

### DIFF
--- a/src/app/api/admin/bots/seed/route.test.ts
+++ b/src/app/api/admin/bots/seed/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
 
 const getSessionMock = vi.fn();
 const enqueueBotSeedJobMock = vi.fn();
@@ -99,8 +100,8 @@ describe("/api/admin/bots/seed", () => {
       dayKey: "2026-02-08",
       triggerType: "ADMIN",
       status: "SUCCEEDED",
-      selectedCount: 5,
-      successCount: 5,
+      selectedCount: BOT_PERSONA_PICK_COUNT,
+      successCount: BOT_PERSONA_PICK_COUNT,
       startedAt: new Date("2026-02-08T01:00:00.000Z"),
       finishedAt: new Date("2026-02-08T01:02:00.000Z"),
       updatedAt: new Date("2026-02-08T01:02:30.000Z"),
@@ -138,8 +139,8 @@ describe("/api/admin/bots/seed", () => {
         dayKey: "2026-02-08",
         triggerType: "ADMIN",
         status: "SUCCEEDED",
-        selectedCount: 5,
-        successCount: 5,
+        selectedCount: BOT_PERSONA_PICK_COUNT,
+        successCount: BOT_PERSONA_PICK_COUNT,
         startedAt: "2026-02-08T01:00:00.000Z",
         finishedAt: "2026-02-08T01:02:00.000Z",
         updatedAt: "2026-02-08T01:02:30.000Z",

--- a/src/entities/bot-persona/api/list-eligible-bot-dishes.test.ts
+++ b/src/entities/bot-persona/api/list-eligible-bot-dishes.test.ts
@@ -97,4 +97,73 @@ describe("listEligibleBotDishes", () => {
       }),
     );
   });
+
+  it("deduplicates by selectedOrder using latest attempt first", async () => {
+    prisma.botSeedItem.findMany.mockResolvedValueOnce([
+      {
+        dishId: "dish-1-attempt2",
+        selectedOrder: 1,
+        personaKey: "triple-silhouette",
+        seedRunId: "run-1",
+        persona: { displayName: "트리플 실루엣" },
+        dish: {
+          imageUrl: "https://cdn.example/dish-1-attempt2.webp",
+          prompt: "attempt2",
+          promptEn: "attempt2",
+          dayScores: [],
+        },
+      },
+      {
+        dishId: "dish-1-attempt1",
+        selectedOrder: 1,
+        personaKey: "triple-silhouette",
+        seedRunId: "run-1",
+        persona: { displayName: "트리플 실루엣" },
+        dish: {
+          imageUrl: "https://cdn.example/dish-1-attempt1.webp",
+          prompt: "attempt1",
+          promptEn: "attempt1",
+          dayScores: [],
+        },
+      },
+      {
+        dishId: "dish-2",
+        selectedOrder: 2,
+        personaKey: "kitchen-madness",
+        seedRunId: "run-1",
+        persona: { displayName: "키친 매드니스" },
+        dish: {
+          imageUrl: "https://cdn.example/dish-2.webp",
+          prompt: "dish2",
+          promptEn: "dish2",
+          dayScores: [],
+        },
+      },
+    ]);
+
+    await expect(listEligibleBotDishes("2026-02-08")).resolves.toEqual([
+      {
+        dishId: "dish-1-attempt2",
+        imageUrl: "https://cdn.example/dish-1-attempt2.webp",
+        prompt: "attempt2",
+        promptEn: "attempt2",
+        personaKey: "triple-silhouette",
+        personaDisplayName: "트리플 실루엣",
+        selectedOrder: 1,
+        dayScore: null,
+        seedRunId: "run-1",
+      },
+      {
+        dishId: "dish-2",
+        imageUrl: "https://cdn.example/dish-2.webp",
+        prompt: "dish2",
+        promptEn: "dish2",
+        personaKey: "kitchen-madness",
+        personaDisplayName: "키친 매드니스",
+        selectedOrder: 2,
+        dayScore: null,
+        seedRunId: "run-1",
+      },
+    ]);
+  });
 });

--- a/src/entities/bot-persona/api/list-eligible-bot-dishes.ts
+++ b/src/entities/bot-persona/api/list-eligible-bot-dishes.ts
@@ -63,12 +63,20 @@ export async function listEligibleBotDishes(dayKey: string): Promise<EligibleBot
     },
   });
 
+  const selectedOrders = new Set<number>();
   return items
     .filter(
       (item): item is typeof item & { dishId: string; dish: NonNullable<typeof item.dish> } => {
         return Boolean(item.dishId && item.dish);
       },
     )
+    .filter((item) => {
+      if (selectedOrders.has(item.selectedOrder)) {
+        return false;
+      }
+      selectedOrders.add(item.selectedOrder);
+      return true;
+    })
     .map((item) => ({
       dishId: item.dishId,
       imageUrl: item.dish.imageUrl,

--- a/src/entities/bot-persona/model/constants.ts
+++ b/src/entities/bot-persona/model/constants.ts
@@ -1,0 +1,1 @@
+export const BOT_PERSONA_PICK_COUNT = 5;

--- a/src/entities/bot-persona/model/select-daily-personas.test.ts
+++ b/src/entities/bot-persona/model/select-daily-personas.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
 import { selectDailyPersonas } from "@/entities/bot-persona/model/select-daily-personas";
 
 const CANDIDATES = [
@@ -44,7 +45,7 @@ describe("selectDailyPersonas", () => {
   it("limits styleGroup concentration when enough candidates exist", () => {
     const result = selectDailyPersonas({
       personas: [...CANDIDATES],
-      pickCount: 5,
+      pickCount: BOT_PERSONA_PICK_COUNT,
       maxPerStyleGroup: 2,
       random: createRandom([0.1, 0.7, 0.3, 0.9, 0.2, 0.8, 0.4]),
     });
@@ -54,14 +55,14 @@ describe("selectDailyPersonas", () => {
       return acc;
     }, {});
 
-    expect(result.selected).toHaveLength(5);
+    expect(result.selected).toHaveLength(BOT_PERSONA_PICK_COUNT);
     expect(Math.max(...Object.values(groupCounts))).toBeLessThanOrEqual(2);
   });
 
   it("returns fallback as remaining active candidates excluding selected", () => {
     const result = selectDailyPersonas({
       personas: [...CANDIDATES],
-      pickCount: 5,
+      pickCount: BOT_PERSONA_PICK_COUNT,
       random: createRandom([0.5, 0.2, 0.8, 0.1, 0.7, 0.3, 0.9]),
     });
 

--- a/src/entities/bot-persona/model/select-daily-personas.ts
+++ b/src/entities/bot-persona/model/select-daily-personas.ts
@@ -1,4 +1,6 @@
-const DEFAULT_PICK_COUNT = 5;
+import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
+
+const DEFAULT_PICK_COUNT = BOT_PERSONA_PICK_COUNT;
 const DEFAULT_MAX_PER_STYLE_GROUP = 2;
 
 export type BotPersonaCandidate = {

--- a/src/workers/bot-seed-handler.test.ts
+++ b/src/workers/bot-seed-handler.test.ts
@@ -91,7 +91,12 @@ describe("processBotSeedJob", () => {
     prisma.botSeedRun.update.mockResolvedValue({ id: "run-1" });
     prisma.botSeedItem.findMany.mockResolvedValue([]);
     prisma.botSeedItem.findFirst.mockResolvedValue(null);
-    prisma.botSeedItem.count.mockResolvedValue(0);
+    prisma.botSeedItem.count.mockImplementation(async () => {
+      return prisma.botSeedItem.create.mock.calls.reduce((count, [payload]) => {
+        const data = (payload as { data?: { status?: string } }).data;
+        return data?.status === "SUCCEEDED" ? count + 1 : count;
+      }, 0);
+    });
     prisma.botSeedItem.deleteMany.mockResolvedValue({ count: 0 });
     prisma.user.upsert.mockResolvedValue({ id: "bot-system-user" });
     prisma.$queryRaw.mockResolvedValue([]);
@@ -170,6 +175,10 @@ describe("processBotSeedJob", () => {
       selected: [{ personaKey: "p1", styleGroup: "g1" }],
       fallback: [],
     });
+    prisma.botSeedItem.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
 
     prisma.botSeedItem.findFirst
       .mockResolvedValueOnce(null)
@@ -193,6 +202,36 @@ describe("processBotSeedJob", () => {
       }),
     );
     expect(result.status).toBe("SUCCEEDED");
+  });
+
+  it("does not overcount success when result is ALREADY_SUCCEEDED but persisted count is lower", async () => {
+    selectDailyPersonas.mockReturnValue({
+      selected: [{ personaKey: "p1", styleGroup: "g1" }],
+      fallback: [],
+    });
+    prisma.botSeedItem.count.mockResolvedValue(0);
+
+    prisma.botSeedItem.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ dishId: "dish-existing" });
+
+    runDishGeneration.mockResolvedValueOnce({
+      status: "ALLOW",
+      imageUrl: "https://cdn.example/a.webp",
+      generationPrompt: "prompt",
+    });
+
+    const result = await processBotSeedJob({ dayKey: "2026-02-09", triggerType: "SCHEDULE" });
+
+    expect(prisma.botSeedRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "FAILED",
+          successCount: 0,
+        }),
+      }),
+    );
+    expect(result.status).toBe("FAILED");
   });
 
   it("does not generate more dishes when remaining slots become zero", async () => {

--- a/src/workers/bot-seed-handler.test.ts
+++ b/src/workers/bot-seed-handler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
 import { ProviderError } from "@/lib/providers/provider-error";
 
 const prisma = vi.hoisted(() => ({
@@ -204,10 +205,10 @@ describe("processBotSeedJob", () => {
     });
 
     prisma.botSeedItem.count
-      .mockResolvedValueOnce(4)
-      .mockResolvedValueOnce(4)
-      .mockResolvedValueOnce(5)
-      .mockResolvedValueOnce(5);
+      .mockResolvedValueOnce(BOT_PERSONA_PICK_COUNT - 1)
+      .mockResolvedValueOnce(BOT_PERSONA_PICK_COUNT - 1)
+      .mockResolvedValueOnce(BOT_PERSONA_PICK_COUNT)
+      .mockResolvedValueOnce(BOT_PERSONA_PICK_COUNT);
 
     runDishGeneration.mockResolvedValue({
       status: "ALLOW",

--- a/src/workers/bot-seed-handler.test.ts
+++ b/src/workers/bot-seed-handler.test.ts
@@ -194,6 +194,33 @@ describe("processBotSeedJob", () => {
     expect(result.status).toBe("SUCCEEDED");
   });
 
+  it("does not generate more dishes when remaining slots become zero", async () => {
+    selectDailyPersonas.mockReturnValue({
+      selected: [
+        { personaKey: "p1", styleGroup: "g1" },
+        { personaKey: "p2", styleGroup: "g2" },
+      ],
+      fallback: [],
+    });
+
+    prisma.botSeedItem.count
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(5);
+
+    runDishGeneration.mockResolvedValue({
+      status: "ALLOW",
+      imageUrl: "https://cdn.example/a.webp",
+      generationPrompt: "prompt",
+    });
+
+    await processBotSeedJob({ dayKey: "2026-02-09", triggerType: "SCHEDULE" });
+
+    expect(runDishGeneration).toHaveBeenCalledTimes(1);
+    expect(prisma.dish.create).toHaveBeenCalledTimes(1);
+  });
+
   it("retries selected persona once and then uses fallback persona", async () => {
     selectDailyPersonas.mockReturnValue({
       selected: [{ personaKey: "p1", styleGroup: "g1" }],

--- a/src/workers/bot-seed-handler.test.ts
+++ b/src/workers/bot-seed-handler.test.ts
@@ -23,12 +23,15 @@ const prisma = vi.hoisted(() => ({
   },
   botSeedItem: {
     findMany: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
     deleteMany: vi.fn(),
     create: vi.fn(),
   },
   user: {
     upsert: vi.fn(),
   },
+  $queryRaw: vi.fn(),
   $transaction: vi.fn(),
 }));
 
@@ -86,8 +89,11 @@ describe("processBotSeedJob", () => {
     prisma.botSeedRun.upsert.mockResolvedValue({ id: "run-1" });
     prisma.botSeedRun.update.mockResolvedValue({ id: "run-1" });
     prisma.botSeedItem.findMany.mockResolvedValue([]);
+    prisma.botSeedItem.findFirst.mockResolvedValue(null);
+    prisma.botSeedItem.count.mockResolvedValue(0);
     prisma.botSeedItem.deleteMany.mockResolvedValue({ count: 0 });
     prisma.user.upsert.mockResolvedValue({ id: "bot-system-user" });
+    prisma.$queryRaw.mockResolvedValue([]);
 
     prisma.dish.create.mockResolvedValue({ id: "dish-1" });
     prisma.dish.updateMany.mockResolvedValue({ count: 0 });
@@ -156,6 +162,36 @@ describe("processBotSeedJob", () => {
       selectedCount: 1,
       status: "SUCCEEDED",
     });
+  });
+
+  it("skips duplicate selectedOrder when another worker already succeeded", async () => {
+    selectDailyPersonas.mockReturnValue({
+      selected: [{ personaKey: "p1", styleGroup: "g1" }],
+      fallback: [],
+    });
+
+    prisma.botSeedItem.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ dishId: "dish-existing" });
+
+    runDishGeneration.mockResolvedValueOnce({
+      status: "ALLOW",
+      imageUrl: "https://cdn.example/a.webp",
+      generationPrompt: "prompt",
+    });
+
+    const result = await processBotSeedJob({ dayKey: "2026-02-09", triggerType: "SCHEDULE" });
+
+    expect(prisma.dish.create).not.toHaveBeenCalled();
+    expect(prisma.botSeedRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "SUCCEEDED",
+          successCount: 1,
+        }),
+      }),
+    );
+    expect(result.status).toBe("SUCCEEDED");
   });
 
   it("retries selected persona once and then uses fallback persona", async () => {

--- a/src/workers/bot-seed-handler.ts
+++ b/src/workers/bot-seed-handler.ts
@@ -31,6 +31,12 @@ type PersonaProfile = {
   isActive: boolean;
 };
 
+type PersonaGenerationResult =
+  | { outcome: "SUCCESS"; nextAttempt: number }
+  | { outcome: "ALREADY_SUCCEEDED"; nextAttempt: number }
+  | { outcome: "CAP_REACHED"; nextAttempt: number; remainingSlots: number }
+  | { outcome: "FAILED"; nextAttempt: number };
+
 function normalizeDayKey(dayKey?: string) {
   const trimmed = dayKey?.trim();
   return trimmed || formatDayKeyForKST();
@@ -49,6 +55,15 @@ function normalizeErrorCode(error: unknown) {
 
 function normalizeErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isUniqueConstraintError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "P2002"
+  );
 }
 
 function computeSeedRunStatus(selectedCount: number, successCount: number): BotSeedRunStatus {
@@ -222,14 +237,56 @@ export async function processBotSeedJob(
   let fallbackCursor = 0;
   let processingError: unknown = null;
 
+  const countRemainingSlots = async () => {
+    const succeededCountForRun = await prisma.botSeedItem.count({
+      where: {
+        seedRunId: seedRun.id,
+        status: "SUCCEEDED",
+        dishId: { not: null },
+      },
+    });
+    return Math.max(0, TARGET_BOT_PERSONA_COUNT - succeededCountForRun);
+  };
+
   const runPersonaGeneration = async (args: {
     persona: PersonaProfile;
     selectedOrder: number;
     attemptStart: number;
-  }) => {
+  }): Promise<PersonaGenerationResult> => {
     let attempt = args.attemptStart;
 
     for (let retry = 0; retry < 2; retry += 1) {
+      const remainingSlots = await countRemainingSlots();
+      if (remainingSlots <= 0) {
+        console.info("[bot-seed] stop generation because no remaining slots", {
+          dayKey,
+          selectedOrder: args.selectedOrder,
+          personaKey: args.persona.personaKey,
+          remainingSlots,
+        });
+        return { outcome: "CAP_REACHED", nextAttempt: attempt, remainingSlots };
+      }
+
+      const existingSucceeded = await prisma.botSeedItem.findFirst({
+        where: {
+          seedRunId: seedRun.id,
+          selectedOrder: args.selectedOrder,
+          status: "SUCCEEDED",
+          dishId: { not: null },
+        },
+        select: { dishId: true },
+      });
+      if (existingSucceeded?.dishId) {
+        console.info("[bot-seed] skip generation because selectedOrder already succeeded", {
+          dayKey,
+          selectedOrder: args.selectedOrder,
+          personaKey: args.persona.personaKey,
+          dishId: existingSucceeded.dishId,
+          remainingSlots,
+        });
+        return { outcome: "ALREADY_SUCCEEDED", nextAttempt: attempt };
+      }
+
       const botPrompts = await resolveBotGenerationPrompts({
         themeText: theme.themeText,
         themeTextEn: theme.themeTextEn,
@@ -266,7 +323,34 @@ export async function processBotSeedJob(
           continue;
         }
 
-        const dishId = await prisma.$transaction(async (tx) => {
+        const txResult = await prisma.$transaction(async (tx) => {
+          // Lock one run row so concurrent workers for the same dayKey serialize success writes.
+          await tx.$queryRaw`SELECT id FROM bot_seed_run WHERE id = ${seedRun.id} FOR UPDATE`;
+
+          const alreadySucceeded = await tx.botSeedItem.findFirst({
+            where: {
+              seedRunId: seedRun.id,
+              selectedOrder: args.selectedOrder,
+              status: "SUCCEEDED",
+              dishId: { not: null },
+            },
+            select: { dishId: true },
+          });
+          if (alreadySucceeded?.dishId) {
+            return { state: "ALREADY_SUCCEEDED" as const, dishId: alreadySucceeded.dishId };
+          }
+
+          const succeededCountForRun = await tx.botSeedItem.count({
+            where: {
+              seedRunId: seedRun.id,
+              status: "SUCCEEDED",
+              dishId: { not: null },
+            },
+          });
+          if (succeededCountForRun >= TARGET_BOT_PERSONA_COUNT) {
+            return { state: "CAP_REACHED" as const, dishId: null };
+          }
+
           const dish = await tx.dish.create({
             data: {
               userId: BOT_SYSTEM_USER_ID,
@@ -307,8 +391,38 @@ export async function processBotSeedJob(
             },
           });
 
-          return dish.id;
+          return { state: "CREATED" as const, dishId: dish.id };
         });
+
+        if (txResult.state === "CAP_REACHED") {
+          console.info("[bot-seed] stop generation because cap reached", {
+            dayKey,
+            selectedOrder: args.selectedOrder,
+            personaKey: args.persona.personaKey,
+            cap: TARGET_BOT_PERSONA_COUNT,
+            remainingSlots: 0,
+          });
+          return { outcome: "CAP_REACHED", nextAttempt: attempt, remainingSlots: 0 };
+        }
+
+        if (txResult.state === "ALREADY_SUCCEEDED") {
+          const remainingSlots = await countRemainingSlots();
+          console.info(
+            "[bot-seed] skip generation in transaction because selectedOrder already succeeded",
+            {
+              dayKey,
+              selectedOrder: args.selectedOrder,
+              personaKey: args.persona.personaKey,
+              remainingSlots,
+            },
+          );
+          return { outcome: "ALREADY_SUCCEEDED", nextAttempt: attempt };
+        }
+
+        const dishId = txResult.dishId;
+        if (!dishId) {
+          return { outcome: "FAILED", nextAttempt: attempt };
+        }
 
         try {
           await enqueueDishScoreJob({ dishId, dayKey });
@@ -321,8 +435,35 @@ export async function processBotSeedJob(
           });
         }
 
-        return { success: true as const, nextAttempt: attempt + 1 };
+        return { outcome: "SUCCESS", nextAttempt: attempt + 1 };
       } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          const afterConflictSucceeded = await prisma.botSeedItem.findFirst({
+            where: {
+              seedRunId: seedRun.id,
+              selectedOrder: args.selectedOrder,
+              status: "SUCCEEDED",
+              dishId: { not: null },
+            },
+            select: { dishId: true },
+          });
+          if (afterConflictSucceeded?.dishId) {
+            const remainingSlots = await countRemainingSlots();
+            console.info(
+              "[bot-seed] skip generation after unique conflict because selectedOrder succeeded",
+              {
+                dayKey,
+                selectedOrder: args.selectedOrder,
+                personaKey: args.persona.personaKey,
+                remainingSlots,
+              },
+            );
+            return { outcome: "ALREADY_SUCCEEDED", nextAttempt: attempt + 1 };
+          }
+          attempt += 1;
+          continue;
+        }
+
         try {
           await prisma.botSeedItem.create({
             data: {
@@ -345,9 +486,10 @@ export async function processBotSeedJob(
       }
     }
 
-    return { success: false as const, nextAttempt: attempt };
+    return { outcome: "FAILED", nextAttempt: attempt };
   };
 
+  let capReached = false;
   try {
     for (let slotIndex = 0; slotIndex < selectedCount; slotIndex += 1) {
       const selectedOrder = slotIndex + 1;
@@ -360,9 +502,13 @@ export async function processBotSeedJob(
         attemptStart,
       });
 
-      if (primaryResult.success) {
+      if (primaryResult.outcome === "SUCCESS" || primaryResult.outcome === "ALREADY_SUCCEEDED") {
         successCount += 1;
         continue;
+      }
+      if (primaryResult.outcome === "CAP_REACHED") {
+        capReached = true;
+        break;
       }
 
       attemptStart = primaryResult.nextAttempt;
@@ -378,22 +524,42 @@ export async function processBotSeedJob(
         attemptStart,
       });
 
-      if (fallbackResult.success) {
+      if (fallbackResult.outcome === "SUCCESS" || fallbackResult.outcome === "ALREADY_SUCCEEDED") {
         successCount += 1;
+      }
+      if (fallbackResult.outcome === "CAP_REACHED") {
+        capReached = true;
+        break;
       }
     }
   } catch (error) {
     processingError = error;
   }
 
+  if (capReached) {
+    console.info("[bot-seed] loop finished early because cap was reached", {
+      dayKey,
+      cap: TARGET_BOT_PERSONA_COUNT,
+    });
+  }
+
+  const persistedSuccessCount = await prisma.botSeedItem.count({
+    where: {
+      seedRunId: seedRun.id,
+      status: "SUCCEEDED",
+      dishId: { not: null },
+    },
+  });
+  const finalSuccessCount = Math.max(successCount, persistedSuccessCount);
+
   // 활성 페르소나가 0개면 당일 시드 구성이 불가능하므로 실패로 기록한다.
-  const status = computeSeedRunStatus(selectedCount, successCount);
+  const status = computeSeedRunStatus(selectedCount, finalSuccessCount);
 
   await prisma.botSeedRun.update({
     where: { id: seedRun.id },
     data: {
       status,
-      successCount,
+      successCount: finalSuccessCount,
       finishedAt: new Date(),
     },
   });

--- a/src/workers/bot-seed-handler.ts
+++ b/src/workers/bot-seed-handler.ts
@@ -1,4 +1,4 @@
-import type { BotSeedRunStatus, BotSeedTriggerType } from "@prisma/client";
+import { type BotSeedRunStatus, type BotSeedTriggerType, Prisma } from "@prisma/client";
 import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
 import { selectDailyPersonas } from "@/entities/bot-persona/model/select-daily-personas";
 import { getOrCreateDayTheme } from "@/lib/day-theme/get-or-create-day-theme";
@@ -58,12 +58,7 @@ function normalizeErrorMessage(error: unknown) {
 }
 
 function isUniqueConstraintError(error: unknown) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: string }).code === "P2002"
-  );
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
 }
 
 function computeSeedRunStatus(selectedCount: number, successCount: number): BotSeedRunStatus {
@@ -233,7 +228,6 @@ export async function processBotSeedJob(
     return run;
   });
 
-  let successCount = 0;
   let fallbackCursor = 0;
   let processingError: unknown = null;
 
@@ -503,7 +497,6 @@ export async function processBotSeedJob(
       });
 
       if (primaryResult.outcome === "SUCCESS" || primaryResult.outcome === "ALREADY_SUCCEEDED") {
-        successCount += 1;
         continue;
       }
       if (primaryResult.outcome === "CAP_REACHED") {
@@ -524,9 +517,6 @@ export async function processBotSeedJob(
         attemptStart,
       });
 
-      if (fallbackResult.outcome === "SUCCESS" || fallbackResult.outcome === "ALREADY_SUCCEEDED") {
-        successCount += 1;
-      }
       if (fallbackResult.outcome === "CAP_REACHED") {
         capReached = true;
         break;
@@ -550,7 +540,7 @@ export async function processBotSeedJob(
       dishId: { not: null },
     },
   });
-  const finalSuccessCount = Math.max(successCount, persistedSuccessCount);
+  const finalSuccessCount = persistedSuccessCount;
 
   // 활성 페르소나가 0개면 당일 시드 구성이 불가능하므로 실패로 기록한다.
   const status = computeSeedRunStatus(selectedCount, finalSuccessCount);

--- a/src/workers/bot-seed-handler.ts
+++ b/src/workers/bot-seed-handler.ts
@@ -1,4 +1,5 @@
 import type { BotSeedRunStatus, BotSeedTriggerType } from "@prisma/client";
+import { BOT_PERSONA_PICK_COUNT } from "@/entities/bot-persona/model/constants";
 import { selectDailyPersonas } from "@/entities/bot-persona/model/select-daily-personas";
 import { getOrCreateDayTheme } from "@/lib/day-theme/get-or-create-day-theme";
 import { prisma } from "@/lib/prisma";
@@ -8,7 +9,6 @@ import { enqueueDishScoreJob } from "@/lib/queue/dish-score-job";
 import { formatDayKeyForKST } from "@/shared/lib/day-key";
 import { runDishGeneration } from "@/workers/services/run-dish-generation";
 
-const TARGET_BOT_PERSONA_COUNT = 5;
 const BOT_SYSTEM_USER_ID = "bot-system-user";
 const BOT_SYSTEM_USER_NAME = "AI Chef Bot";
 
@@ -157,7 +157,7 @@ export async function processBotSeedJob(
   const personaByKey = new Map(personas.map((persona) => [persona.personaKey, persona]));
   const { selected, fallback } = selectDailyPersonas({
     personas,
-    pickCount: TARGET_BOT_PERSONA_COUNT,
+    pickCount: BOT_PERSONA_PICK_COUNT,
   });
 
   const selectedProfiles = selected
@@ -245,7 +245,7 @@ export async function processBotSeedJob(
         dishId: { not: null },
       },
     });
-    return Math.max(0, TARGET_BOT_PERSONA_COUNT - succeededCountForRun);
+    return Math.max(0, BOT_PERSONA_PICK_COUNT - succeededCountForRun);
   };
 
   const runPersonaGeneration = async (args: {
@@ -347,7 +347,7 @@ export async function processBotSeedJob(
               dishId: { not: null },
             },
           });
-          if (succeededCountForRun >= TARGET_BOT_PERSONA_COUNT) {
+          if (succeededCountForRun >= BOT_PERSONA_PICK_COUNT) {
             return { state: "CAP_REACHED" as const, dishId: null };
           }
 
@@ -399,7 +399,7 @@ export async function processBotSeedJob(
             dayKey,
             selectedOrder: args.selectedOrder,
             personaKey: args.persona.personaKey,
-            cap: TARGET_BOT_PERSONA_COUNT,
+            cap: BOT_PERSONA_PICK_COUNT,
             remainingSlots: 0,
           });
           return { outcome: "CAP_REACHED", nextAttempt: attempt, remainingSlots: 0 };
@@ -539,7 +539,7 @@ export async function processBotSeedJob(
   if (capReached) {
     console.info("[bot-seed] loop finished early because cap was reached", {
       dayKey,
-      cap: TARGET_BOT_PERSONA_COUNT,
+      cap: BOT_PERSONA_PICK_COUNT,
     });
   }
 


### PR DESCRIPTION
## 개요

- 변경 목적:
  - bot-seed 워커의 재시도/중복 실행/동시 실행 상황에서 bot dish가 5개를 초과 생성하는 문제를 해결한다.
  - 생성 개수 기준값을 단일 공유 상수로 통합해 향후 정책 변경 시 수정 누락 위험을 줄인다.
- 사용자 영향:
  - 일일 bot dish 노출이 안정적으로 상한 이내로 유지된다.
  - 운영자가 재시드를 수행해도 중복 생성으로 인한 피드 왜곡 가능성이 낮아진다.

## 변경 사항

- [x] `bot-seed-handler`에 생성 전 `remainingSlots` 계산 및 상한 도달 시 조기 종료 처리 추가
- [x] 트랜잭션 내부 `FOR UPDATE` + 성공 개수 재검증으로 동시성 환경에서 상한 초과 생성 차단
- [x] `selectedOrder` 기준 멱등 스킵 및 `P2002` 충돌 후 재확인 로직으로 중복 성공 레코드 누적 방지
- [x] `listEligibleBotDishes`에서 `selectedOrder` 기준 dedupe 적용(최신 attempt 우선)
- [x] bot 생성 개수 기준을 `BOT_PERSONA_PICK_COUNT` 단일 공유 상수로 통합
- [x] 관련 테스트(`bot-seed-handler`, `select-daily-personas`, `admin/bots/seed`, `list-eligible-bot-dishes`) 보강

## 테스트

- [x] `pnpm test src/workers/bot-seed-handler.test.ts src/entities/bot-persona/api/list-eligible-bot-dishes.test.ts` — PASS (15/15) (2026-02-15)
- [x] `pnpm test src/workers/bot-seed-handler.test.ts src/entities/bot-persona/model/select-daily-personas.test.ts src/app/api/admin/bots/seed/route.test.ts src/entities/bot-persona/api/list-eligible-bot-dishes.test.ts` — PASS (27/27) (2026-02-15)

## 스크린샷 / 다이어그램

```mermaid
sequenceDiagram
    participant API as Admin Seed API
    participant Worker as bot-seed-handler
    participant Persona as listEligibleBotDishes
    participant DB as DB(Transaction)

    API->>Worker: seed(dayKey, triggerType)
    Worker->>DB: countExistingSuccesses(dayKey)
    DB-->>Worker: existingCount
    Worker->>Worker: remainingSlots = PICK_COUNT - existingCount
    alt remainingSlots <= 0
        Worker-->>API: stop (already full)
    else remainingSlots > 0
        Worker->>Persona: getEligible(dayKey, remainingSlots)
        Persona-->>Worker: deduped candidates(selectedOrder)
        loop candidate in selectedOrder
            Worker->>DB: BEGIN + FOR UPDATE
            Worker->>DB: recountSuccesses(dayKey)
            alt count >= PICK_COUNT
                Worker->>DB: ROLLBACK
            else count < PICK_COUNT
                Worker->>DB: create dish(unique dayKey+selectedOrder)
                alt P2002 duplicate
                    Worker->>DB: verify existing success and skip
                end
                Worker->>DB: COMMIT
            end
        end
    end
```

## 관련 문서

- Spec: `./spec.md`
- Tasks: `./tasks.md`
- Decisions: `./decisions.md`
- Issue: `#26`

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 동일한 선택 순서 항목의 중복 제거 로직 적용
  * 동시 처리 환경에서 중복 선택 방지 및 성공 집계 정확성 향상
  * 남은 슬롯 한도 준수로 과생성 방지

* **Refactor**
  * 선택 개수 관련 하드코딩 값 중앙화

* **Tests**
  * 중복 처리·슬롯 소진·집계 관련 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->