### PR TITLE
feat(#30): daily-ranking-system (매치 의존 제거 및 일간 랭킹 정합화)

### DIFF
--- a/src/app/api/ranking/[dayKey]/route.test.ts
+++ b/src/app/api/ranking/[dayKey]/route.test.ts
@@ -195,6 +195,30 @@ describe("GET /api/ranking/[dayKey]", () => {
     });
   });
 
+  it("returns 400 when includeBots query is invalid", async () => {
+    const { GET } = await import("./route");
+
+    const topResponse = await GET(
+      new Request("http://localhost/api/ranking/2026-02-11?includeBots=flase"),
+      {
+        params: Promise.resolve({ dayKey: "2026-02-11" }),
+      },
+    );
+    const archiveResponse = await GET(
+      new Request("http://localhost/api/ranking/2026-02-11?view=archive&includeBots=maybe"),
+      {
+        params: Promise.resolve({ dayKey: "2026-02-11" }),
+      },
+    );
+
+    expect(topResponse.status).toBe(400);
+    await expect(topResponse.json()).resolves.toEqual({ error: "INVALID_INCLUDE_BOTS" });
+    expect(archiveResponse.status).toBe(400);
+    await expect(archiveResponse.json()).resolves.toEqual({ error: "INVALID_INCLUDE_BOTS" });
+    expect(getRankingTopMock).not.toHaveBeenCalled();
+    expect(listRankingArchiveMock).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when dayKey format is invalid", async () => {
     const { GET } = await import("./route");
 

--- a/src/app/api/ranking/[dayKey]/route.test.ts
+++ b/src/app/api/ranking/[dayKey]/route.test.ts
@@ -42,6 +42,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 10,
+      includeBots: false,
     });
   });
 
@@ -55,6 +56,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 7,
+      includeBots: false,
     });
   });
 
@@ -71,10 +73,12 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenNthCalledWith(1, {
       dayKey: "2026-02-11",
       count: 10,
+      includeBots: false,
     });
     expect(getRankingTopMock).toHaveBeenNthCalledWith(2, {
       dayKey: "2026-02-11",
       count: 10,
+      includeBots: false,
     });
   });
 
@@ -88,6 +92,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 50,
+      includeBots: false,
     });
   });
 
@@ -109,6 +114,7 @@ describe("GET /api/ranking/[dayKey]", () => {
       limit: 15,
       offset: 30,
       search: "ramen",
+      includeBots: false,
     });
     expect(getRankingTopMock).not.toHaveBeenCalled();
   });
@@ -125,6 +131,37 @@ describe("GET /api/ranking/[dayKey]", () => {
       limit: 12,
       offset: 0,
       search: null,
+      includeBots: false,
+    });
+  });
+
+  it("passes includeBots=true to top and archive handlers", async () => {
+    const { GET } = await import("./route");
+
+    await GET(new Request("http://localhost/api/ranking/2026-02-11?count=5&includeBots=true"), {
+      params: Promise.resolve({ dayKey: "2026-02-11" }),
+    });
+
+    await GET(
+      new Request(
+        "http://localhost/api/ranking/2026-02-11?view=archive&includeBots=1&limit=10&offset=0",
+      ),
+      {
+        params: Promise.resolve({ dayKey: "2026-02-11" }),
+      },
+    );
+
+    expect(getRankingTopMock).toHaveBeenCalledWith({
+      dayKey: "2026-02-11",
+      count: 5,
+      includeBots: true,
+    });
+    expect(listRankingArchiveMock).toHaveBeenCalledWith({
+      dayKey: "2026-02-11",
+      limit: 10,
+      offset: 0,
+      search: null,
+      includeBots: true,
     });
   });
 

--- a/src/app/api/ranking/[dayKey]/route.test.ts
+++ b/src/app/api/ranking/[dayKey]/route.test.ts
@@ -42,7 +42,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 10,
-      includeBots: false,
+      includeBots: true,
     });
   });
 
@@ -56,7 +56,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 7,
-      includeBots: false,
+      includeBots: true,
     });
   });
 
@@ -73,12 +73,12 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenNthCalledWith(1, {
       dayKey: "2026-02-11",
       count: 10,
-      includeBots: false,
+      includeBots: true,
     });
     expect(getRankingTopMock).toHaveBeenNthCalledWith(2, {
       dayKey: "2026-02-11",
       count: 10,
-      includeBots: false,
+      includeBots: true,
     });
   });
 
@@ -92,7 +92,7 @@ describe("GET /api/ranking/[dayKey]", () => {
     expect(getRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-11",
       count: 50,
-      includeBots: false,
+      includeBots: true,
     });
   });
 
@@ -114,7 +114,7 @@ describe("GET /api/ranking/[dayKey]", () => {
       limit: 15,
       offset: 30,
       search: "ramen",
-      includeBots: false,
+      includeBots: true,
     });
     expect(getRankingTopMock).not.toHaveBeenCalled();
   });
@@ -131,7 +131,7 @@ describe("GET /api/ranking/[dayKey]", () => {
       limit: 12,
       offset: 0,
       search: null,
-      includeBots: false,
+      includeBots: true,
     });
   });
 
@@ -162,6 +162,36 @@ describe("GET /api/ranking/[dayKey]", () => {
       offset: 0,
       search: null,
       includeBots: true,
+    });
+  });
+
+  it("passes includeBots=false to top and archive handlers", async () => {
+    const { GET } = await import("./route");
+
+    await GET(new Request("http://localhost/api/ranking/2026-02-11?count=5&includeBots=false"), {
+      params: Promise.resolve({ dayKey: "2026-02-11" }),
+    });
+
+    await GET(
+      new Request(
+        "http://localhost/api/ranking/2026-02-11?view=archive&includeBots=0&limit=10&offset=0",
+      ),
+      {
+        params: Promise.resolve({ dayKey: "2026-02-11" }),
+      },
+    );
+
+    expect(getRankingTopMock).toHaveBeenCalledWith({
+      dayKey: "2026-02-11",
+      count: 5,
+      includeBots: false,
+    });
+    expect(listRankingArchiveMock).toHaveBeenCalledWith({
+      dayKey: "2026-02-11",
+      limit: 10,
+      offset: 0,
+      search: null,
+      includeBots: false,
     });
   });
 

--- a/src/app/api/ranking/[dayKey]/route.ts
+++ b/src/app/api/ranking/[dayKey]/route.ts
@@ -54,6 +54,12 @@ function getArchiveSearch(url: string) {
   return search ? search : null;
 }
 
+function getIncludeBots(url: string) {
+  const { searchParams } = new URL(url);
+  const value = searchParams.get("includeBots")?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
 export async function GET(
   request: Request,
   context: {
@@ -70,17 +76,20 @@ export async function GET(
     const limit = getArchiveLimit(request.url);
     const offset = getArchiveOffset(request.url);
     const search = getArchiveSearch(request.url);
+    const includeBots = getIncludeBots(request.url);
     return NextResponse.json(
       await listRankingArchive({
         dayKey,
         limit,
         offset,
         search,
+        includeBots,
       }),
     );
   }
 
   const count = getRankingCount(request.url);
+  const includeBots = getIncludeBots(request.url);
   const source = getHomeDataSource();
-  return NextResponse.json(await source.getRankingTop({ dayKey, count }));
+  return NextResponse.json(await source.getRankingTop({ dayKey, count, includeBots }));
 }

--- a/src/app/api/ranking/[dayKey]/route.ts
+++ b/src/app/api/ranking/[dayKey]/route.ts
@@ -57,7 +57,16 @@ function getArchiveSearch(url: string) {
 function getIncludeBots(url: string) {
   const { searchParams } = new URL(url);
   const value = searchParams.get("includeBots")?.trim().toLowerCase();
-  return value === "1" || value === "true";
+  if (!value) {
+    return true;
+  }
+  if (value === "0" || value === "false") {
+    return false;
+  }
+  if (value === "1" || value === "true") {
+    return true;
+  }
+  return true;
 }
 
 export async function GET(

--- a/src/app/api/ranking/[dayKey]/route.ts
+++ b/src/app/api/ranking/[dayKey]/route.ts
@@ -66,7 +66,7 @@ function getIncludeBots(url: string) {
   if (value === "1" || value === "true") {
     return true;
   }
-  return true;
+  throw new Error("INVALID_INCLUDE_BOTS");
 }
 
 export async function GET(
@@ -80,12 +80,17 @@ export async function GET(
   if (!DAY_KEY_PATTERN.test(dayKey)) {
     return NextResponse.json({ error: "INVALID_DAY_KEY" }, { status: 400 });
   }
+  let includeBots: boolean;
+  try {
+    includeBots = getIncludeBots(request.url);
+  } catch {
+    return NextResponse.json({ error: "INVALID_INCLUDE_BOTS" }, { status: 400 });
+  }
   const view = getView(request.url);
   if (view === RANKING_VIEW_ARCHIVE) {
     const limit = getArchiveLimit(request.url);
     const offset = getArchiveOffset(request.url);
     const search = getArchiveSearch(request.url);
-    const includeBots = getIncludeBots(request.url);
     return NextResponse.json(
       await listRankingArchive({
         dayKey,
@@ -98,7 +103,6 @@ export async function GET(
   }
 
   const count = getRankingCount(request.url);
-  const includeBots = getIncludeBots(request.url);
   const source = getHomeDataSource();
   return NextResponse.json(await source.getRankingTop({ dayKey, count, includeBots }));
 }

--- a/src/entities/ranking/api/list-ranking-archive.test.ts
+++ b/src/entities/ranking/api/list-ranking-archive.test.ts
@@ -78,9 +78,29 @@ describe("listRankingArchive", () => {
       dishId: "dish-1",
       dishName: "매콤 버터 마늘 라멘",
     });
+    expect(prisma.dishDayScore.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+            botMeta: null,
+          },
+        },
+      }),
+    );
     expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+            botMeta: null,
+          },
+        },
         orderBy: [
           { totalScore: "desc" },
           { themeFit: "desc" },
@@ -93,6 +113,14 @@ describe("listRankingArchive", () => {
     expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+            botMeta: null,
+          },
+        },
         orderBy: [
           { totalScore: "desc" },
           { themeFit: "desc" },
@@ -244,5 +272,49 @@ describe("listRankingArchive", () => {
       rank: 2,
     });
     expect(result.nextOffset).toBeNull();
+  });
+
+  it("includes bot dishes only when includeBots=true", async () => {
+    prisma.dayTheme.findUnique.mockResolvedValueOnce({
+      themeText: "비 오는 날",
+      axisA: "비",
+      axisB: "국물",
+      axisFlavor: "매콤",
+    });
+    prisma.dishDayScore.aggregate.mockResolvedValueOnce({
+      _count: { _all: 1 },
+      _avg: { totalScore: 90 },
+    });
+    prisma.dishDayScore.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const { listRankingArchive } = await import("./list-ranking-archive");
+    await listRankingArchive({
+      dayKey: "2026-02-12",
+      includeBots: true,
+    });
+
+    expect(prisma.dishDayScore.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+          },
+        },
+      }),
+    );
+    expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/entities/ranking/api/list-ranking-archive.test.ts
+++ b/src/entities/ranking/api/list-ranking-archive.test.ts
@@ -78,6 +78,30 @@ describe("listRankingArchive", () => {
       dishId: "dish-1",
       dishName: "매콤 버터 마늘 라멘",
     });
+    expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        orderBy: [
+          { totalScore: "desc" },
+          { themeFit: "desc" },
+          { execution: "desc" },
+          { analyzedAt: "desc" },
+          { id: "desc" },
+        ],
+      }),
+    );
+    expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        orderBy: [
+          { totalScore: "desc" },
+          { themeFit: "desc" },
+          { execution: "desc" },
+          { analyzedAt: "desc" },
+          { id: "desc" },
+        ],
+      }),
+    );
     expect(result.nextOffset).toBe(1);
     expect(result.keywordGroups.length).toBeGreaterThan(0);
   });

--- a/src/entities/ranking/api/list-ranking-archive.test.ts
+++ b/src/entities/ranking/api/list-ranking-archive.test.ts
@@ -315,5 +315,18 @@ describe("listRankingArchive", () => {
         },
       }),
     );
+    expect(prisma.dishDayScore.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+            botMeta: null,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/entities/ranking/api/list-ranking-archive.test.ts
+++ b/src/entities/ranking/api/list-ranking-archive.test.ts
@@ -85,7 +85,6 @@ describe("listRankingArchive", () => {
           status: "READY",
           dish: {
             isHidden: false,
-            botMeta: null,
           },
         },
       }),
@@ -98,7 +97,6 @@ describe("listRankingArchive", () => {
           status: "READY",
           dish: {
             isHidden: false,
-            botMeta: null,
           },
         },
         orderBy: [
@@ -118,7 +116,6 @@ describe("listRankingArchive", () => {
           status: "READY",
           dish: {
             isHidden: false,
-            botMeta: null,
           },
         },
         orderBy: [
@@ -274,7 +271,7 @@ describe("listRankingArchive", () => {
     expect(result.nextOffset).toBeNull();
   });
 
-  it("includes bot dishes only when includeBots=true", async () => {
+  it("excludes bot dishes when includeBots=false", async () => {
     prisma.dayTheme.findUnique.mockResolvedValueOnce({
       themeText: "비 오는 날",
       axisA: "비",
@@ -290,7 +287,7 @@ describe("listRankingArchive", () => {
     const { listRankingArchive } = await import("./list-ranking-archive");
     await listRankingArchive({
       dayKey: "2026-02-12",
-      includeBots: true,
+      includeBots: false,
     });
 
     expect(prisma.dishDayScore.aggregate).toHaveBeenCalledWith(
@@ -300,6 +297,7 @@ describe("listRankingArchive", () => {
           status: "READY",
           dish: {
             isHidden: false,
+            botMeta: null,
           },
         },
       }),
@@ -312,6 +310,7 @@ describe("listRankingArchive", () => {
           status: "READY",
           dish: {
             isHidden: false,
+            botMeta: null,
           },
         },
       }),

--- a/src/entities/ranking/api/list-ranking-archive.ts
+++ b/src/entities/ranking/api/list-ranking-archive.ts
@@ -179,6 +179,7 @@ export async function listRankingArchive(args: {
   includeBots?: boolean;
 }): Promise<RankingArchiveResponse> {
   const dayKey = args.dayKey.trim();
+  const includeBots = args.includeBots ?? true;
   const limit = toSafeLimit(args.limit);
   const offset = toSafeOffset(args.offset);
   const search = toSafeSearch(args.search);
@@ -209,7 +210,7 @@ export async function listRankingArchive(args: {
       where: {
         dayKey,
         status: "READY",
-        dish: getPublicRankingDishWhere({ includeBots: args.includeBots }),
+        dish: getPublicRankingDishWhere({ includeBots }),
       },
       _count: {
         _all: true,
@@ -223,7 +224,7 @@ export async function listRankingArchive(args: {
         dayKey,
         status: "READY",
         dish: {
-          ...getPublicRankingDishWhere({ includeBots: args.includeBots }),
+          ...getPublicRankingDishWhere({ includeBots }),
           ...(search ? { dishName: { contains: search, mode: "insensitive" as const } } : {}),
         },
       },
@@ -259,7 +260,7 @@ export async function listRankingArchive(args: {
       where: {
         dayKey,
         status: "READY",
-        dish: getPublicRankingDishWhere({ includeBots: args.includeBots }),
+        dish: getPublicRankingDishWhere({ includeBots }),
       },
       orderBy: getRankingOrderBy(),
       take: 30,
@@ -280,7 +281,7 @@ export async function listRankingArchive(args: {
       ? await fetchGlobalRankByDishId({
           dayKey,
           dishIds: visibleRows.map((row) => row.dishId),
-          includeBots: args.includeBots ?? true,
+          includeBots,
         })
       : null;
   const items = globalRankByDishId

--- a/src/entities/ranking/api/list-ranking-archive.ts
+++ b/src/entities/ranking/api/list-ranking-archive.ts
@@ -280,7 +280,7 @@ export async function listRankingArchive(args: {
       ? await fetchGlobalRankByDishId({
           dayKey,
           dishIds: visibleRows.map((row) => row.dishId),
-          includeBots: args.includeBots ?? false,
+          includeBots: args.includeBots ?? true,
         })
       : null;
   const items = globalRankByDishId

--- a/src/entities/ranking/api/list-ranking-archive.ts
+++ b/src/entities/ranking/api/list-ranking-archive.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@prisma/client";
+import { getRankingOrderBy, RANKING_SQL_ORDER_BY } from "@/entities/ranking/model/ranking-policy";
 import type { RankingArchiveEntry, RankingArchiveResponse } from "@/entities/ranking/model/types";
 import { prisma } from "@/lib/prisma";
 
@@ -141,7 +142,7 @@ async function fetchGlobalRankByDishId(dayKey: string, dishIds: string[]) {
     WITH ranked AS (
       SELECT
         dds."dishId",
-        ROW_NUMBER() OVER (ORDER BY dds."totalScore" DESC, dds."analyzedAt" DESC, dds."id" DESC) AS rank
+        ROW_NUMBER() OVER (ORDER BY ${Prisma.raw(RANKING_SQL_ORDER_BY)}) AS rank
       FROM "dish_day_score" dds
       INNER JOIN "dish" d ON d."id" = dds."dishId"
       WHERE
@@ -214,7 +215,7 @@ export async function listRankingArchive(args: {
           ...(search ? { dishName: { contains: search, mode: "insensitive" as const } } : {}),
         },
       },
-      orderBy: [{ totalScore: "desc" }, { analyzedAt: "desc" }, { id: "desc" }],
+      orderBy: getRankingOrderBy(),
       skip: offset,
       take: limit + 1,
       select: {
@@ -250,7 +251,7 @@ export async function listRankingArchive(args: {
           isHidden: false,
         },
       },
-      orderBy: [{ totalScore: "desc" }, { analyzedAt: "desc" }, { id: "desc" }],
+      orderBy: getRankingOrderBy(),
       take: 30,
       select: {
         dish: {

--- a/src/entities/ranking/api/list-ranking-archive.ts
+++ b/src/entities/ranking/api/list-ranking-archive.ts
@@ -1,5 +1,9 @@
 import { Prisma } from "@prisma/client";
-import { getRankingOrderBy, RANKING_SQL_ORDER_BY } from "@/entities/ranking/model/ranking-policy";
+import {
+  getPublicRankingDishWhere,
+  getRankingOrderBy,
+  RANKING_SQL_ORDER_BY,
+} from "@/entities/ranking/model/ranking-policy";
 import type { RankingArchiveEntry, RankingArchiveResponse } from "@/entities/ranking/model/types";
 import { prisma } from "@/lib/prisma";
 
@@ -128,10 +132,18 @@ function buildKeywordGroups(args: {
   ];
 }
 
-async function fetchGlobalRankByDishId(dayKey: string, dishIds: string[]) {
+async function fetchGlobalRankByDishId(args: {
+  dayKey: string;
+  dishIds: string[];
+  includeBots: boolean;
+}) {
+  const { dayKey, dishIds, includeBots } = args;
   if (dishIds.length === 0) {
     return new Map<string, number>();
   }
+  const botFilterSql = includeBots
+    ? Prisma.empty
+    : Prisma.sql`AND NOT EXISTS (SELECT 1 FROM "dish_bot_meta" dbm WHERE dbm."dishId" = d."id")`;
 
   // 검색 결과에서도 "당일 전체 기준 순위"를 유지해야 하므로 DB 윈도우 함수(ROW_NUMBER)를 사용한다.
   // Prisma findMany로 전체 행을 메모리에 올리는 방식은 참가자 수 증가 시 비용이 커져 회피한다.
@@ -149,6 +161,7 @@ async function fetchGlobalRankByDishId(dayKey: string, dishIds: string[]) {
         dds."dayKey" = ${dayKey}
         AND dds."status" = 'READY'
         AND d."isHidden" = false
+        ${botFilterSql}
     )
     SELECT ranked."dishId", ranked.rank
     FROM ranked
@@ -163,6 +176,7 @@ export async function listRankingArchive(args: {
   limit?: number;
   offset?: number;
   search?: string | null;
+  includeBots?: boolean;
 }): Promise<RankingArchiveResponse> {
   const dayKey = args.dayKey.trim();
   const limit = toSafeLimit(args.limit);
@@ -195,9 +209,7 @@ export async function listRankingArchive(args: {
       where: {
         dayKey,
         status: "READY",
-        dish: {
-          isHidden: false,
-        },
+        dish: getPublicRankingDishWhere({ includeBots: args.includeBots }),
       },
       _count: {
         _all: true,
@@ -211,7 +223,7 @@ export async function listRankingArchive(args: {
         dayKey,
         status: "READY",
         dish: {
-          isHidden: false,
+          ...getPublicRankingDishWhere({ includeBots: args.includeBots }),
           ...(search ? { dishName: { contains: search, mode: "insensitive" as const } } : {}),
         },
       },
@@ -247,9 +259,7 @@ export async function listRankingArchive(args: {
       where: {
         dayKey,
         status: "READY",
-        dish: {
-          isHidden: false,
-        },
+        dish: getPublicRankingDishWhere({ includeBots: args.includeBots }),
       },
       orderBy: getRankingOrderBy(),
       take: 30,
@@ -267,10 +277,11 @@ export async function listRankingArchive(args: {
   const visibleRows = hasMore ? rows.slice(0, limit) : rows;
   const globalRankByDishId =
     search && visibleRows.length > 0
-      ? await fetchGlobalRankByDishId(
+      ? await fetchGlobalRankByDishId({
           dayKey,
-          visibleRows.map((row) => row.dishId),
-        )
+          dishIds: visibleRows.map((row) => row.dishId),
+          includeBots: args.includeBots ?? false,
+        })
       : null;
   const items = globalRankByDishId
     ? visibleRows.flatMap((row) => {

--- a/src/entities/ranking/api/list-ranking-top.test.ts
+++ b/src/entities/ranking/api/list-ranking-top.test.ts
@@ -49,6 +49,7 @@ describe("listRankingTop", () => {
           status: "READY",
           dish: {
             isHidden: false,
+            botMeta: null,
           },
         },
         orderBy: [
@@ -101,5 +102,24 @@ describe("listRankingTop", () => {
       items: [],
     });
     expect(prisma.dishDayScore.findMany).not.toHaveBeenCalled();
+  });
+
+  it("allows bot dishes only when includeBots=true", async () => {
+    prisma.dishDayScore.findMany.mockResolvedValueOnce([]);
+
+    const { listRankingTop } = await import("./list-ranking-top");
+    await listRankingTop({ dayKey: "2026-02-12", includeBots: true });
+
+    expect(prisma.dishDayScore.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dayKey: "2026-02-12",
+          status: "READY",
+          dish: {
+            isHidden: false,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/entities/ranking/api/list-ranking-top.test.ts
+++ b/src/entities/ranking/api/list-ranking-top.test.ts
@@ -49,7 +49,6 @@ describe("listRankingTop", () => {
           status: "READY",
           dish: {
             isHidden: false,
-            botMeta: null,
           },
         },
         orderBy: [
@@ -104,11 +103,11 @@ describe("listRankingTop", () => {
     expect(prisma.dishDayScore.findMany).not.toHaveBeenCalled();
   });
 
-  it("allows bot dishes only when includeBots=true", async () => {
+  it("excludes bot dishes only when includeBots=false", async () => {
     prisma.dishDayScore.findMany.mockResolvedValueOnce([]);
 
     const { listRankingTop } = await import("./list-ranking-top");
-    await listRankingTop({ dayKey: "2026-02-12", includeBots: true });
+    await listRankingTop({ dayKey: "2026-02-12", includeBots: false });
 
     expect(prisma.dishDayScore.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -117,6 +116,7 @@ describe("listRankingTop", () => {
           status: "READY",
           dish: {
             isHidden: false,
+            botMeta: null,
           },
         },
       }),

--- a/src/entities/ranking/api/list-ranking-top.test.ts
+++ b/src/entities/ranking/api/list-ranking-top.test.ts
@@ -51,6 +51,13 @@ describe("listRankingTop", () => {
             isHidden: false,
           },
         },
+        orderBy: [
+          { totalScore: "desc" },
+          { themeFit: "desc" },
+          { execution: "desc" },
+          { analyzedAt: "desc" },
+          { id: "desc" },
+        ],
         take: 2,
       }),
     );

--- a/src/entities/ranking/api/list-ranking-top.test.ts
+++ b/src/entities/ranking/api/list-ranking-top.test.ts
@@ -71,10 +71,6 @@ describe("listRankingTop", () => {
           authorName: "Chef A",
           imageUrl: "https://cdn.example/dish-1.webp",
           score: 91.2,
-          leftImageUrl: "https://cdn.example/dish-1.webp",
-          rightImageUrl: "https://cdn.example/dish-1.webp",
-          leftScore: 91.2,
-          rightScore: 91.2,
         },
         {
           rank: 2,
@@ -83,10 +79,6 @@ describe("listRankingTop", () => {
           authorName: "트리플 실루엣",
           imageUrl: "https://cdn.example/dish-2.webp",
           score: 88.6,
-          leftImageUrl: "https://cdn.example/dish-2.webp",
-          rightImageUrl: "https://cdn.example/dish-2.webp",
-          leftScore: 88.6,
-          rightScore: 88.6,
         },
       ],
     });

--- a/src/entities/ranking/api/list-ranking-top.ts
+++ b/src/entities/ranking/api/list-ranking-top.ts
@@ -74,10 +74,6 @@ export async function listRankingTop(args: {
         authorName: row.dish.botMeta?.persona.displayName || row.dish.user.name || AUTHOR_FALLBACK,
         imageUrl,
         score,
-        leftImageUrl: imageUrl,
-        rightImageUrl: imageUrl,
-        leftScore: score,
-        rightScore: score,
       };
     }),
   };

--- a/src/entities/ranking/api/list-ranking-top.ts
+++ b/src/entities/ranking/api/list-ranking-top.ts
@@ -1,3 +1,4 @@
+import { getRankingOrderBy } from "@/entities/ranking/model/ranking-policy";
 import type { RankingTop } from "@/entities/ranking/model/types";
 import { prisma } from "@/lib/prisma";
 
@@ -30,7 +31,7 @@ export async function listRankingTop(args: {
         isHidden: false,
       },
     },
-    orderBy: [{ totalScore: "desc" }, { analyzedAt: "desc" }, { id: "desc" }],
+    orderBy: getRankingOrderBy(),
     take: count,
     select: {
       dishId: true,

--- a/src/entities/ranking/api/list-ranking-top.ts
+++ b/src/entities/ranking/api/list-ranking-top.ts
@@ -1,4 +1,7 @@
-import { getRankingOrderBy } from "@/entities/ranking/model/ranking-policy";
+import {
+  getPublicRankingDishWhere,
+  getRankingOrderBy,
+} from "@/entities/ranking/model/ranking-policy";
 import type { RankingTop } from "@/entities/ranking/model/types";
 import { prisma } from "@/lib/prisma";
 
@@ -16,6 +19,7 @@ function toSafeCount(count: number | undefined) {
 export async function listRankingTop(args: {
   dayKey: string;
   count?: number;
+  includeBots?: boolean;
 }): Promise<RankingTop> {
   const dayKey = args.dayKey.toString().trim();
   const count = toSafeCount(args.count);
@@ -27,9 +31,7 @@ export async function listRankingTop(args: {
     where: {
       dayKey,
       status: "READY",
-      dish: {
-        isHidden: false,
-      },
+      dish: getPublicRankingDishWhere({ includeBots: args.includeBots }),
     },
     orderBy: getRankingOrderBy(),
     take: count,

--- a/src/entities/ranking/model/ranking-policy.ts
+++ b/src/entities/ranking/model/ranking-policy.ts
@@ -1,0 +1,21 @@
+import type { Prisma } from "@prisma/client";
+
+export const RANKING_TIE_BREAK_ORDER = [
+  { totalScore: "desc" },
+  { themeFit: "desc" },
+  { execution: "desc" },
+  { analyzedAt: "desc" },
+  { id: "desc" },
+] as const;
+
+export function getRankingOrderBy(): Prisma.DishDayScoreOrderByWithRelationInput[] {
+  return [...RANKING_TIE_BREAK_ORDER];
+}
+
+export const RANKING_SQL_ORDER_BY = `
+  dds."totalScore" DESC,
+  dds."themeFit" DESC,
+  dds."execution" DESC,
+  dds."analyzedAt" DESC,
+  dds."id" DESC
+`;

--- a/src/entities/ranking/model/ranking-policy.ts
+++ b/src/entities/ranking/model/ranking-policy.ts
@@ -21,11 +21,11 @@ export const RANKING_SQL_ORDER_BY = `
 `;
 
 export function getPublicRankingDishWhere(args?: { includeBots?: boolean }): Prisma.DishWhereInput {
-  if (args?.includeBots) {
-    return { isHidden: false };
+  if (args?.includeBots === false) {
+    return {
+      isHidden: false,
+      botMeta: null,
+    };
   }
-  return {
-    isHidden: false,
-    botMeta: null,
-  };
+  return { isHidden: false };
 }

--- a/src/entities/ranking/model/ranking-policy.ts
+++ b/src/entities/ranking/model/ranking-policy.ts
@@ -19,3 +19,13 @@ export const RANKING_SQL_ORDER_BY = `
   dds."analyzedAt" DESC,
   dds."id" DESC
 `;
+
+export function getPublicRankingDishWhere(args?: { includeBots?: boolean }): Prisma.DishWhereInput {
+  if (args?.includeBots) {
+    return { isHidden: false };
+  }
+  return {
+    isHidden: false,
+    botMeta: null,
+  };
+}

--- a/src/entities/ranking/model/ranking-policy.ts
+++ b/src/entities/ranking/model/ranking-policy.ts
@@ -1,24 +1,21 @@
 import type { Prisma } from "@prisma/client";
 
-export const RANKING_TIE_BREAK_ORDER = [
-  { totalScore: "desc" },
-  { themeFit: "desc" },
-  { execution: "desc" },
-  { analyzedAt: "desc" },
-  { id: "desc" },
+const RANKING_ORDER_SPEC = [
+  { field: "totalScore", sql: `dds."totalScore"` },
+  { field: "themeFit", sql: `dds."themeFit"` },
+  { field: "execution", sql: `dds."execution"` },
+  { field: "analyzedAt", sql: `dds."analyzedAt"` },
+  { field: "id", sql: `dds."id"` },
 ] as const;
+
+export const RANKING_TIE_BREAK_ORDER: ReadonlyArray<Prisma.DishDayScoreOrderByWithRelationInput> =
+  RANKING_ORDER_SPEC.map(({ field }) => ({ [field]: "desc" }));
 
 export function getRankingOrderBy(): Prisma.DishDayScoreOrderByWithRelationInput[] {
   return [...RANKING_TIE_BREAK_ORDER];
 }
 
-export const RANKING_SQL_ORDER_BY = `
-  dds."totalScore" DESC,
-  dds."themeFit" DESC,
-  dds."execution" DESC,
-  dds."analyzedAt" DESC,
-  dds."id" DESC
-`;
+export const RANKING_SQL_ORDER_BY = RANKING_ORDER_SPEC.map(({ sql }) => `${sql} DESC`).join(", ");
 
 export function getPublicRankingDishWhere(args?: { includeBots?: boolean }): Prisma.DishWhereInput {
   if (args?.includeBots === false) {

--- a/src/entities/ranking/model/types.ts
+++ b/src/entities/ranking/model/types.ts
@@ -5,16 +5,9 @@ export type RankingEntry = {
   authorName: string;
   imageUrl: string;
   score: number;
-  leftImageUrl: string;
-  rightImageUrl: string;
-  leftScore: number;
-  rightScore: number;
 };
 
-export type RankingArchiveEntry = Omit<
-  RankingEntry,
-  "leftImageUrl" | "rightImageUrl" | "leftScore" | "rightScore"
->;
+export type RankingArchiveEntry = RankingEntry;
 
 export type RankingTop = {
   dayKey: string;

--- a/src/shared/analytics/events.ts
+++ b/src/shared/analytics/events.ts
@@ -13,9 +13,16 @@ export const ANALYTICS_EVENTS = {
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
 
-export const ANALYTICS_EVENT_PAYLOAD_SCHEMA = {
+type AnalyticsPayloadSchema = {
+  required: readonly string[];
+  optional: readonly string[];
+};
+
+export const ANALYTICS_EVENT_PAYLOAD_SCHEMA: Partial<
+  Record<AnalyticsEvent, AnalyticsPayloadSchema>
+> = {
   [ANALYTICS_EVENTS.RANKING_ITEM_CLICKED]: {
     required: ["screen", "dayKey", "dishId"],
     optional: ["rank", "source"],
   },
-} as const;
+};

--- a/src/shared/analytics/events.ts
+++ b/src/shared/analytics/events.ts
@@ -3,7 +3,6 @@ export const ANALYTICS_EVENTS = {
   VIEW_THEME: "view_theme",
   VIEW_RANKING: "view_ranking",
   START_CREATE: "start_create",
-  MATCH_VIEW: "match_view",
   FEED_FILTER_CHANGED: "feed_filter_changed",
   FEED_ITEM_CLICKED: "feed_item_clicked",
   RANKING_ITEM_CLICKED: "ranking_item_clicked",
@@ -13,3 +12,10 @@ export const ANALYTICS_EVENTS = {
 } as const;
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+export const ANALYTICS_EVENT_PAYLOAD_SCHEMA = {
+  [ANALYTICS_EVENTS.RANKING_ITEM_CLICKED]: {
+    required: ["screen", "dayKey", "dishId"],
+    optional: ["rank", "source"],
+  },
+} as const;

--- a/src/shared/analytics/track-event.test.ts
+++ b/src/shared/analytics/track-event.test.ts
@@ -49,10 +49,25 @@ describe("trackEvent", () => {
     expect(gtag).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith("[analytics.client] invalid payload", {
       event: ANALYTICS_EVENTS.RANKING_ITEM_CLICKED,
-      payload: {
-        screen: "home",
-        dayKey: "2026-03-04",
-      },
+      payloadKeys: ["screen", "dayKey"],
+      payloadSize: 2,
+    });
+  });
+
+  it("skips untyped event when payload contains non-primitive value", () => {
+    const gtag = vi.fn();
+    (window as Window & { gtag?: unknown }).gtag = gtag;
+
+    trackEvent(ANALYTICS_EVENTS.VIEW_HOME, {
+      screen: "home",
+      meta: { nested: true },
+    } as unknown as Record<string, string | number | boolean | null | undefined>);
+
+    expect(gtag).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("[analytics.client] invalid payload", {
+      event: ANALYTICS_EVENTS.VIEW_HOME,
+      payloadKeys: ["screen", "meta"],
+      payloadSize: 2,
     });
   });
 });

--- a/src/shared/analytics/track-event.test.ts
+++ b/src/shared/analytics/track-event.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
+import { trackEvent } from "@/shared/analytics/track-event";
+
+const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  afterEach(() => {
+    delete (window as Window & { gtag?: unknown }).gtag;
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("sends event when payload satisfies schema", () => {
+    const gtag = vi.fn();
+    (window as Window & { gtag?: unknown }).gtag = gtag;
+
+    trackEvent(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "home",
+      dayKey: "2026-03-04",
+      dishId: "dish-1",
+      rank: 1,
+    });
+
+    expect(gtag).toHaveBeenCalledWith("event", ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "home",
+      dayKey: "2026-03-04",
+      dishId: "dish-1",
+      rank: 1,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips event when required payload key is missing", () => {
+    const gtag = vi.fn();
+    (window as Window & { gtag?: unknown }).gtag = gtag;
+
+    trackEvent(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "home",
+      dayKey: "2026-03-04",
+    });
+
+    expect(gtag).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("[analytics.client] invalid payload", {
+      event: ANALYTICS_EVENTS.RANKING_ITEM_CLICKED,
+      payload: {
+        screen: "home",
+        dayKey: "2026-03-04",
+      },
+    });
+  });
+});

--- a/src/shared/analytics/track-event.ts
+++ b/src/shared/analytics/track-event.ts
@@ -1,9 +1,14 @@
 import type { AnalyticsEvent } from "@/shared/analytics/events";
+import { validateAnalyticsPayload } from "@/shared/analytics/validate-payload";
 
 type TrackPayload = Record<string, string | number | boolean | undefined | null>;
 
 export function trackEvent(event: AnalyticsEvent, payload: TrackPayload = {}) {
   if (typeof window === "undefined") {
+    return;
+  }
+  if (!validateAnalyticsPayload(event, payload)) {
+    console.warn("[analytics.client] invalid payload", { event, payload });
     return;
   }
 

--- a/src/shared/analytics/track-event.ts
+++ b/src/shared/analytics/track-event.ts
@@ -8,7 +8,12 @@ export function trackEvent(event: AnalyticsEvent, payload: TrackPayload = {}) {
     return;
   }
   if (!validateAnalyticsPayload(event, payload)) {
-    console.warn("[analytics.client] invalid payload", { event, payload });
+    const payloadKeys = Object.keys(payload);
+    console.warn("[analytics.client] invalid payload", {
+      event,
+      payloadKeys,
+      payloadSize: payloadKeys.length,
+    });
     return;
   }
 

--- a/src/shared/analytics/track-server-event.test.ts
+++ b/src/shared/analytics/track-server-event.test.ts
@@ -48,10 +48,22 @@ describe("trackServerEvent", () => {
     expect(infoSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith("[analytics.server] invalid payload", {
       event: ANALYTICS_EVENTS.RANKING_ITEM_CLICKED,
-      payload: {
-        screen: "ranking",
-        dayKey: "2026-03-04",
-      },
+      payloadKeys: ["screen", "dayKey"],
+      payloadSize: 2,
+    });
+  });
+
+  it("skips untyped event when payload contains non-primitive value", () => {
+    trackServerEvent(ANALYTICS_EVENTS.VIEW_HOME, {
+      screen: "ranking",
+      meta: { nested: true },
+    } as unknown as Record<string, string | number | boolean | null | undefined>);
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("[analytics.server] invalid payload", {
+      event: ANALYTICS_EVENTS.VIEW_HOME,
+      payloadKeys: ["screen", "meta"],
+      payloadSize: 2,
     });
   });
 });

--- a/src/shared/analytics/track-server-event.test.ts
+++ b/src/shared/analytics/track-server-event.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
+import { trackServerEvent } from "@/shared/analytics/track-server-event";
+
+const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+describe("trackServerEvent", () => {
+  beforeEach(() => {
+    infoSpy.mockClear();
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("logs event when payload satisfies schema", () => {
+    trackServerEvent(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "ranking",
+      dayKey: "2026-03-04",
+      dishId: "dish-10",
+      source: "archive",
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[analytics.server]",
+      expect.objectContaining({
+        event: ANALYTICS_EVENTS.RANKING_ITEM_CLICKED,
+        payload: {
+          screen: "ranking",
+          dayKey: "2026-03-04",
+          dishId: "dish-10",
+          source: "archive",
+        },
+      }),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips event when required payload key is missing", () => {
+    trackServerEvent(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "ranking",
+      dayKey: "2026-03-04",
+    });
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("[analytics.server] invalid payload", {
+      event: ANALYTICS_EVENTS.RANKING_ITEM_CLICKED,
+      payload: {
+        screen: "ranking",
+        dayKey: "2026-03-04",
+      },
+    });
+  });
+});

--- a/src/shared/analytics/track-server-event.ts
+++ b/src/shared/analytics/track-server-event.ts
@@ -5,7 +5,12 @@ type ServerEventPayload = Record<string, string | number | boolean | null | unde
 
 export function trackServerEvent(event: AnalyticsEvent, payload: ServerEventPayload = {}) {
   if (!validateAnalyticsPayload(event, payload)) {
-    console.warn("[analytics.server] invalid payload", { event, payload });
+    const payloadKeys = Object.keys(payload);
+    console.warn("[analytics.server] invalid payload", {
+      event,
+      payloadKeys,
+      payloadSize: payloadKeys.length,
+    });
     return;
   }
 

--- a/src/shared/analytics/track-server-event.ts
+++ b/src/shared/analytics/track-server-event.ts
@@ -1,8 +1,14 @@
 import type { AnalyticsEvent } from "@/shared/analytics/events";
+import { validateAnalyticsPayload } from "@/shared/analytics/validate-payload";
 
 type ServerEventPayload = Record<string, string | number | boolean | null | undefined>;
 
 export function trackServerEvent(event: AnalyticsEvent, payload: ServerEventPayload = {}) {
+  if (!validateAnalyticsPayload(event, payload)) {
+    console.warn("[analytics.server] invalid payload", { event, payload });
+    return;
+  }
+
   console.info("[analytics.server]", {
     event,
     payload,

--- a/src/shared/analytics/validate-payload.ts
+++ b/src/shared/analytics/validate-payload.ts
@@ -1,0 +1,35 @@
+import { ANALYTICS_EVENT_PAYLOAD_SCHEMA, type AnalyticsEvent } from "@/shared/analytics/events";
+
+type AnalyticsPayloadValue = string | number | boolean;
+
+function hasOwn(payload: Record<string, unknown>, key: string) {
+  return Object.hasOwn(payload, key);
+}
+
+function isPayloadValue(value: unknown): value is AnalyticsPayloadValue {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+export function validateAnalyticsPayload(
+  event: AnalyticsEvent,
+  payload: Record<string, unknown>,
+): payload is Record<string, AnalyticsPayloadValue> {
+  const schema = ANALYTICS_EVENT_PAYLOAD_SCHEMA[event];
+  if (!schema) {
+    return true;
+  }
+
+  for (const key of schema.required) {
+    if (!hasOwn(payload, key) || !isPayloadValue(payload[key])) {
+      return false;
+    }
+  }
+
+  for (const key of schema.optional) {
+    if (hasOwn(payload, key) && !isPayloadValue(payload[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/shared/analytics/validate-payload.ts
+++ b/src/shared/analytics/validate-payload.ts
@@ -10,13 +10,17 @@ function isPayloadValue(value: unknown): value is AnalyticsPayloadValue {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
 }
 
+function isLightweightPayloadValue(value: unknown) {
+  return isPayloadValue(value) || value === null || value === undefined;
+}
+
 export function validateAnalyticsPayload(
   event: AnalyticsEvent,
   payload: Record<string, unknown>,
 ): payload is Record<string, AnalyticsPayloadValue> {
   const schema = ANALYTICS_EVENT_PAYLOAD_SCHEMA[event];
   if (!schema) {
-    return true;
+    return Object.values(payload).every((value) => isLightweightPayloadValue(value));
   }
 
   for (const key of schema.required) {

--- a/src/shared/api/home-data-source.test.ts
+++ b/src/shared/api/home-data-source.test.ts
@@ -25,10 +25,6 @@ describe("home-data-source", () => {
           authorName: "Chef A",
           imageUrl: "https://cdn.example/dish-1.webp",
           score: 91,
-          leftImageUrl: "https://cdn.example/dish-1-left.webp",
-          rightImageUrl: "https://cdn.example/dish-1-right.webp",
-          leftScore: 9.1,
-          rightScore: 8.7,
         },
       ],
     });
@@ -44,6 +40,10 @@ describe("home-data-source", () => {
     expect(feed.items).toHaveLength(1);
     expect(feed.items[0]?.dayKey).toBe("2026-02-08");
     expect(feed.items[0]?.id).toBe("dish-1");
+    expect(feed.items[0]?.leftDishImageUrl).toBe("https://cdn.example/dish-1.webp");
+    expect(feed.items[0]?.rightDishImageUrl).toBe("https://cdn.example/dish-1.webp");
+    expect(feed.items[0]?.leftScore).toBe(91);
+    expect(feed.items[0]?.rightScore).toBe(91);
   });
 
   it("returns DB ranking via adapter interface", async () => {
@@ -57,10 +57,6 @@ describe("home-data-source", () => {
           authorName: "Chef A",
           imageUrl: "https://cdn.example/dish-1.webp",
           score: 91,
-          leftImageUrl: "https://cdn.example/dish-1.webp",
-          rightImageUrl: "https://cdn.example/dish-1.webp",
-          leftScore: 91,
-          rightScore: 91,
         },
       ],
     });

--- a/src/shared/api/home-data-source.test.ts
+++ b/src/shared/api/home-data-source.test.ts
@@ -14,12 +14,36 @@ describe("home-data-source", () => {
     vi.clearAllMocks();
   });
 
-  it("returns mock match feed via adapter interface", async () => {
+  it("returns ranking-derived feed via adapter interface", async () => {
+    listRankingTopMock.mockResolvedValueOnce({
+      dayKey: "2026-02-08",
+      items: [
+        {
+          rank: 1,
+          dishId: "dish-1",
+          dishName: "dish",
+          authorName: "Chef A",
+          imageUrl: "https://cdn.example/dish-1.webp",
+          score: 91,
+          leftImageUrl: "https://cdn.example/dish-1-left.webp",
+          rightImageUrl: "https://cdn.example/dish-1-right.webp",
+          leftScore: 9.1,
+          rightScore: 8.7,
+        },
+      ],
+    });
+
     const source = getHomeDataSource();
     const feed = await source.getMatchFeed({ dayKey: "2026-02-08", limit: 3 });
 
-    expect(feed.items).toHaveLength(3);
+    expect(listRankingTopMock).toHaveBeenCalledWith({
+      dayKey: "2026-02-08",
+      count: 3,
+      includeBots: false,
+    });
+    expect(feed.items).toHaveLength(1);
     expect(feed.items[0]?.dayKey).toBe("2026-02-08");
+    expect(feed.items[0]?.id).toBe("dish-1");
   });
 
   it("returns DB ranking via adapter interface", async () => {

--- a/src/shared/api/home-data-source.test.ts
+++ b/src/shared/api/home-data-source.test.ts
@@ -39,7 +39,7 @@ describe("home-data-source", () => {
     expect(listRankingTopMock).toHaveBeenCalledWith({
       dayKey: "2026-02-08",
       count: 3,
-      includeBots: false,
+      includeBots: true,
     });
     expect(feed.items).toHaveLength(1);
     expect(feed.items[0]?.dayKey).toBe("2026-02-08");

--- a/src/shared/api/home-data-source.ts
+++ b/src/shared/api/home-data-source.ts
@@ -16,7 +16,7 @@ const mockHomeDataSource: HomeDataSource = {
     const rankingTop = await listRankingTop({
       dayKey: args.dayKey,
       count: args.limit,
-      includeBots: false,
+      includeBots: true,
     });
 
     return {

--- a/src/shared/api/home-data-source.ts
+++ b/src/shared/api/home-data-source.ts
@@ -1,7 +1,6 @@
 import type { MatchFeed } from "@/entities/match/model/types";
 import { listRankingTop } from "@/entities/ranking/api/list-ranking-top";
 import type { RankingTop } from "@/entities/ranking/model/types";
-import { getMockMatchFeed } from "@/shared/api/mock-home-data";
 
 export type HomeDataSource = {
   getMatchFeed(args: { dayKey: string; limit: number }): Promise<MatchFeed>;
@@ -14,14 +13,29 @@ export type HomeDataSource = {
 
 const mockHomeDataSource: HomeDataSource = {
   async getMatchFeed(args) {
-    return getMockMatchFeed(args.dayKey, args.limit);
+    const rankingTop = await listRankingTop({
+      dayKey: args.dayKey,
+      count: args.limit,
+      includeBots: false,
+    });
+
+    return {
+      items: rankingTop.items.map((entry) => ({
+        id: entry.dishId,
+        dayKey: rankingTop.dayKey,
+        leftDishImageUrl: entry.leftImageUrl,
+        rightDishImageUrl: entry.rightImageUrl,
+        leftScore: entry.leftScore,
+        rightScore: entry.rightScore,
+        isPractice: false,
+      })),
+    };
   },
   async getRankingTop(args) {
     return listRankingTop(args);
   },
 };
 
-// matchFeed는 추후 실제 매치 데이터 연동 시 교체한다.
 export function getHomeDataSource(): HomeDataSource {
   return mockHomeDataSource;
 }

--- a/src/shared/api/home-data-source.ts
+++ b/src/shared/api/home-data-source.ts
@@ -23,10 +23,10 @@ const mockHomeDataSource: HomeDataSource = {
       items: rankingTop.items.map((entry) => ({
         id: entry.dishId,
         dayKey: rankingTop.dayKey,
-        leftDishImageUrl: entry.leftImageUrl,
-        rightDishImageUrl: entry.rightImageUrl,
-        leftScore: entry.leftScore,
-        rightScore: entry.rightScore,
+        leftDishImageUrl: entry.imageUrl,
+        rightDishImageUrl: entry.imageUrl,
+        leftScore: entry.score,
+        rightScore: entry.score,
         isPractice: false,
       })),
     };

--- a/src/shared/api/home-data-source.ts
+++ b/src/shared/api/home-data-source.ts
@@ -5,7 +5,11 @@ import { getMockMatchFeed } from "@/shared/api/mock-home-data";
 
 export type HomeDataSource = {
   getMatchFeed(args: { dayKey: string; limit: number }): Promise<MatchFeed>;
-  getRankingTop(args: { dayKey: string; count: number }): Promise<RankingTop>;
+  getRankingTop(args: {
+    dayKey: string;
+    count: number;
+    includeBots?: boolean;
+  }): Promise<RankingTop>;
 };
 
 const mockHomeDataSource: HomeDataSource = {

--- a/src/shared/api/mock-home-data.ts
+++ b/src/shared/api/mock-home-data.ts
@@ -31,21 +31,14 @@ export function getMockMe(): MeResponse {
 
 function makeRankingEntry(dayKey: string, rank: number): RankingEntry {
   const baseSeed = `${dayKey}-rank-${pad(rank)}`;
-  const leftScore = 8.8 - rank * 0.2;
-  const rightScore = 8.3 - rank * 0.18;
-  const isLeftWinner = leftScore >= rightScore;
-  const score = isLeftWinner ? leftScore : rightScore;
+  const score = 9.6 - rank * 0.25;
   return {
     rank,
     dishId: baseSeed,
     dishName: `Hall Dish #${pad(rank)}`,
     authorName: `Chef_${pad(rank)}`,
-    imageUrl: dishImage(`${baseSeed}-${isLeftWinner ? "left" : "right"}`),
+    imageUrl: dishImage(baseSeed),
     score,
-    leftImageUrl: dishImage(`${baseSeed}-left`),
-    rightImageUrl: dishImage(`${baseSeed}-right`),
-    leftScore,
-    rightScore,
   };
 }
 

--- a/src/shared/api/mock-home-data.ts
+++ b/src/shared/api/mock-home-data.ts
@@ -31,7 +31,7 @@ export function getMockMe(): MeResponse {
 
 function makeRankingEntry(dayKey: string, rank: number): RankingEntry {
   const baseSeed = `${dayKey}-rank-${pad(rank)}`;
-  const score = 9.6 - rank * 0.25;
+  const score = Math.max(0, 9.6 - rank * 0.25);
   return {
     rank,
     dishId: baseSeed,

--- a/src/shared/api/mock-home-data.ts
+++ b/src/shared/api/mock-home-data.ts
@@ -1,4 +1,3 @@
-import type { MatchFeed, MatchSummary } from "@/entities/match/model/types";
 import type { RankingEntry, RankingTop } from "@/entities/ranking/model/types";
 import type { Theme } from "@/entities/theme/model/types";
 import { formatDayKey, formatDayKeyForTimeZone } from "@/shared/lib/day-key";
@@ -28,27 +27,6 @@ export function getMockTheme(dayKey = formatDayKey()): Theme {
 
 export function getMockMe(): MeResponse {
   return { status: "ELIGIBLE" };
-}
-
-function makeMatch(dayKey: string, index: number): MatchSummary {
-  const id = `${dayKey}-match-${pad(index + 1)}`;
-  const leftScore = 7.5 + (index % 3) * 0.6;
-  const rightScore = 7.2 + (index % 4) * 0.5;
-  return {
-    id,
-    dayKey,
-    leftDishImageUrl: dishImage(`${id}-left`),
-    rightDishImageUrl: dishImage(`${id}-right`),
-    leftScore,
-    rightScore,
-    isPractice: index % 5 === 0,
-  };
-}
-
-export function getMockMatchFeed(dayKey = formatDayKey(), limit = 8): MatchFeed {
-  const safeLimit = Math.max(0, Math.floor(Number(limit)));
-  const items = Array.from({ length: safeLimit }, (_, index) => makeMatch(dayKey, index));
-  return { items };
 }
 
 function makeRankingEntry(dayKey: string, rank: number): RankingEntry {

--- a/src/widgets/home/highlights/highlights.test.tsx
+++ b/src/widgets/home/highlights/highlights.test.tsx
@@ -77,6 +77,7 @@ describe("Highlights", () => {
       screen: "home",
       dayKey: "2026-01-26",
       rank: 1,
+      dishId: "dish-1",
     });
   });
 });

--- a/src/widgets/home/highlights/highlights.test.tsx
+++ b/src/widgets/home/highlights/highlights.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
 import Highlights from "./highlights";
 
@@ -34,11 +34,15 @@ const rankingTop = {
 };
 
 describe("Highlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders ranking cards", () => {
     render(<Highlights rankingTop={rankingTop} />);
 
     expect(screen.getByText(/오늘의 랭킹 — Top Rated/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View Ranking" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "랭킹 보기" })).toBeInTheDocument();
     expect(screen.getByText("Hall Dish #01")).toBeInTheDocument();
     expect(screen.getByText("Chef_01")).toBeInTheDocument();
     expect(screen.queryByText("vs")).not.toBeInTheDocument();

--- a/src/widgets/home/highlights/highlights.test.tsx
+++ b/src/widgets/home/highlights/highlights.test.tsx
@@ -1,6 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
 import Highlights from "./highlights";
+
+const { trackEventMock } = vi.hoisted(() => ({
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock("@/shared/analytics/track-event", () => ({
+  trackEvent: trackEventMock,
+}));
 
 const rankingTop = {
   dayKey: "2026-01-26",
@@ -56,5 +65,18 @@ describe("Highlights", () => {
     render(<Highlights rankingTop={rankingTop} isRestricted />);
 
     expect(screen.getByText("하이라이트 제한")).toBeInTheDocument();
+  });
+
+  it("tracks ranking click event payload", () => {
+    render(<Highlights rankingTop={rankingTop} />);
+
+    const cardLink = screen.getByRole("link", { name: /Hall Dish #01/i });
+    fireEvent.click(cardLink);
+
+    expect(trackEventMock).toHaveBeenCalledWith(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "home",
+      dayKey: "2026-01-26",
+      rank: 1,
+    });
   });
 });

--- a/src/widgets/home/highlights/highlights.test.tsx
+++ b/src/widgets/home/highlights/highlights.test.tsx
@@ -12,10 +12,6 @@ const rankingTop = {
       authorName: "Chef_01",
       imageUrl: "https://example.com/winner-1.jpg",
       score: 9.8,
-      leftImageUrl: "https://example.com/left.jpg",
-      rightImageUrl: "https://example.com/right.jpg",
-      leftScore: 9.8,
-      rightScore: 8.5,
     },
     {
       rank: 2,
@@ -24,10 +20,6 @@ const rankingTop = {
       authorName: "Chef_02",
       imageUrl: "https://example.com/winner-2.jpg",
       score: 9.2,
-      leftImageUrl: "",
-      rightImageUrl: "",
-      leftScore: 9.2,
-      rightScore: 9.1,
     },
   ],
 };
@@ -38,6 +30,11 @@ describe("Highlights", () => {
 
     expect(screen.getByText(/오늘의 랭킹 — Top Rated/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View Ranking" })).toBeInTheDocument();
+    expect(screen.getByText("Hall Dish #01")).toBeInTheDocument();
+    expect(screen.getByText("Chef_01")).toBeInTheDocument();
+    expect(screen.queryByText("vs")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Winner:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/대결/)).not.toBeInTheDocument();
 
     const links = screen.getAllByRole("link");
     expect(links.some((link) => link.getAttribute("href") === "/ranking/2026-01-26")).toBe(true);

--- a/src/widgets/home/highlights/highlights.tsx
+++ b/src/widgets/home/highlights/highlights.tsx
@@ -54,61 +54,40 @@ function HighlightCard({
   dayKey: string;
   onClick?: () => void;
 }) {
-  const winnerIsLeft = entry.leftScore > entry.rightScore;
-  const winnerLabel = winnerIsLeft ? "Left" : "Right";
-  const chefHandle = `@chef-${String(entry.rank).padStart(2, "0")}`;
-  const title = `랭킹 #${entry.rank} 대결`;
-
   return (
     <Link
       className="group rounded-[2rem] border border-white/5 bg-card/90 p-4 shadow-lg transition hover:border-primary/40 hover:shadow-xl"
       href={`/ranking/${dayKey}`}
       onClick={onClick}
     >
-      <div className="relative grid h-48 grid-cols-2 gap-1 overflow-hidden rounded-[1.5rem]">
-        <div className="h-full w-full bg-card">
-          {entry.leftImageUrl ? (
-            <img
-              alt={`Ranking left ${entry.rank}`}
-              className="h-full w-full object-cover"
-              src={entry.leftImageUrl}
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-card via-background to-black text-xs text-white/40">
-              No Image
-            </div>
-          )}
-        </div>
-        <div className="h-full w-full bg-card">
-          {entry.rightImageUrl ? (
-            <img
-              alt={`Ranking right ${entry.rank}`}
-              className="h-full w-full object-cover"
-              src={entry.rightImageUrl}
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-card via-background to-black text-xs text-white/40">
-              No Image
-            </div>
-          )}
-        </div>
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="-skew-x-12 rounded-full border border-white/10 bg-black/80 px-4 py-1 text-xl font-black italic text-white shadow-lg">
-            <span className="not-italic text-primary">{formatScore(entry.leftScore)}</span>
-            <span className="px-2 text-sm font-normal not-italic text-white/50">vs</span>
-            <span className="not-italic">{formatScore(entry.rightScore)}</span>
+      <div className="relative h-52 overflow-hidden rounded-[1.5rem] bg-card">
+        {entry.imageUrl ? (
+          <img
+            alt={`Ranking #${entry.rank} ${entry.dishName}`}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+            src={entry.imageUrl}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-card via-background to-black text-xs text-white/40">
+            No Image
           </div>
+        )}
+        <div className="absolute left-3 top-3 rounded-full border border-white/15 bg-black/75 px-3 py-1 text-xs font-semibold text-white">
+          #{entry.rank}
+        </div>
+        <div className="absolute bottom-3 right-3 rounded-md bg-black/80 px-2 py-1 text-base font-black text-primary">
+          {formatScore(entry.score)}
         </div>
       </div>
       <div className="mt-4 flex items-start justify-between px-2">
         <div className="flex flex-col gap-1">
-          <h3 className="text-lg font-bold leading-tight text-white">{title}</h3>
+          <h3 className="line-clamp-1 text-lg font-bold leading-tight text-white">
+            {entry.dishName}
+          </h3>
           <div className="flex items-center gap-2">
-            <span className="text-xs font-bold uppercase tracking-[0.2em] text-primary">
-              Winner: {winnerLabel}
-            </span>
+            <span className="line-clamp-1 text-xs text-white/70">{entry.authorName}</span>
             <span className="text-xs text-white/30">•</span>
-            <span className="text-xs text-white/60">{chefHandle}</span>
+            <span className="text-xs text-white/60">Rank #{entry.rank}</span>
           </div>
         </div>
         <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white transition group-hover:bg-primary group-hover:text-black">

--- a/src/widgets/home/highlights/highlights.tsx
+++ b/src/widgets/home/highlights/highlights.tsx
@@ -145,6 +145,7 @@ export default function Highlights({ rankingTop, isError, isRestricted }: Highli
               screen: "home",
               dayKey: rankingTop.dayKey,
               rank: entry.rank,
+              dishId: entry.dishId,
             });
           };
 

--- a/src/widgets/home/highlights/highlights.tsx
+++ b/src/widgets/home/highlights/highlights.tsx
@@ -38,7 +38,7 @@ function HighlightsHeader({ dayKey }: { dayKey?: string }) {
         className="flex items-center gap-1 text-sm font-medium text-white/60 transition hover:text-primary"
         href={href}
       >
-        View Ranking
+        랭킹 보기
         <ArrowRight aria-hidden className="h-4 w-4" />
       </Link>
     </div>
@@ -54,6 +54,8 @@ function HighlightCard({
   dayKey: string;
   onClick?: () => void;
 }) {
+  const dishName = entry.dishName || "알 수 없는 메뉴";
+
   return (
     <Link
       className="group rounded-[2rem] border border-white/5 bg-card/90 p-4 shadow-lg transition hover:border-primary/40 hover:shadow-xl"
@@ -63,17 +65,17 @@ function HighlightCard({
       <div className="relative h-52 overflow-hidden rounded-[1.5rem] bg-card">
         {entry.imageUrl ? (
           <img
-            alt={`Ranking #${entry.rank} ${entry.dishName}`}
+            alt={`랭킹 #${entry.rank} ${dishName}`}
             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
             src={entry.imageUrl}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-card via-background to-black text-xs text-white/40">
-            No Image
+            이미지 없음
           </div>
         )}
         <div className="absolute left-3 top-3 rounded-full border border-white/15 bg-black/75 px-3 py-1 text-xs font-semibold text-white">
-          #{entry.rank}
+          랭킹 #{entry.rank}
         </div>
         <div className="absolute bottom-3 right-3 rounded-md bg-black/80 px-2 py-1 text-base font-black text-primary">
           {formatScore(entry.score)}
@@ -81,13 +83,11 @@ function HighlightCard({
       </div>
       <div className="mt-4 flex items-start justify-between px-2">
         <div className="flex flex-col gap-1">
-          <h3 className="line-clamp-1 text-lg font-bold leading-tight text-white">
-            {entry.dishName}
-          </h3>
+          <h3 className="line-clamp-1 text-lg font-bold leading-tight text-white">{dishName}</h3>
           <div className="flex items-center gap-2">
             <span className="line-clamp-1 text-xs text-white/70">{entry.authorName}</span>
             <span className="text-xs text-white/30">•</span>
-            <span className="text-xs text-white/60">Rank #{entry.rank}</span>
+            <span className="text-xs text-white/60">랭킹 #{entry.rank}</span>
           </div>
         </div>
         <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white transition group-hover:bg-primary group-hover:text-black">

--- a/src/widgets/home/match-grid/match-grid.test.tsx
+++ b/src/widgets/home/match-grid/match-grid.test.tsx
@@ -1,6 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
 import MatchGrid from "./match-grid";
+
+const { trackEventMock } = vi.hoisted(() => ({
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock("@/shared/analytics/track-event", () => ({
+  trackEvent: trackEventMock,
+}));
 
 const matchFeed = {
   items: [
@@ -33,5 +42,19 @@ describe("MatchGrid", () => {
     render(<MatchGrid matchFeed={null} />);
 
     expect(screen.getByText("랭킹 하이라이트가 없습니다")).toBeInTheDocument();
+  });
+
+  it("tracks ranking click event payload", () => {
+    render(<MatchGrid matchFeed={matchFeed} />);
+
+    const cardLink = screen.getByRole("link", { name: /연습전/i });
+    fireEvent.click(cardLink);
+
+    expect(trackEventMock).toHaveBeenCalledWith(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
+      screen: "home",
+      dayKey: "2026-01-26",
+      dishId: "match-1",
+      source: "home_match_grid",
+    });
   });
 });

--- a/src/widgets/home/match-grid/match-grid.test.tsx
+++ b/src/widgets/home/match-grid/match-grid.test.tsx
@@ -20,20 +20,18 @@ describe("MatchGrid", () => {
   it("renders match cards with practice label", () => {
     render(<MatchGrid matchFeed={matchFeed} />);
 
-    expect(screen.getByText(/최신 매치 1개/)).toBeInTheDocument();
+    expect(screen.getByText(/랭킹 하이라이트 1개/)).toBeInTheDocument();
     expect(screen.getByText("연습전")).toBeInTheDocument();
 
     expect(screen.getByRole("link", { name: "View Feed" })).toBeInTheDocument();
 
     const links = screen.getAllByRole("link");
-    expect(links.some((link) => link.getAttribute("href") === "/matches/match-1")).toBe(
-      true,
-    );
+    expect(links.some((link) => link.getAttribute("href") === "/ranking/2026-01-26")).toBe(true);
   });
 
   it("renders empty state when no matches", () => {
     render(<MatchGrid matchFeed={null} />);
 
-    expect(screen.getByText("매치가 없습니다")).toBeInTheDocument();
+    expect(screen.getByText("랭킹 하이라이트가 없습니다")).toBeInTheDocument();
   });
 });

--- a/src/widgets/home/match-grid/match-grid.test.tsx
+++ b/src/widgets/home/match-grid/match-grid.test.tsx
@@ -31,6 +31,8 @@ describe("MatchGrid", () => {
 
     expect(screen.getByText(/랭킹 하이라이트 1개/)).toBeInTheDocument();
     expect(screen.getByText("연습전")).toBeInTheDocument();
+    expect(screen.getByText("Top Score 9.6")).toBeInTheDocument();
+    expect(screen.queryByText(/vs/i)).not.toBeInTheDocument();
 
     expect(screen.getByRole("link", { name: "View Feed" })).toBeInTheDocument();
 

--- a/src/widgets/home/match-grid/match-grid.tsx
+++ b/src/widgets/home/match-grid/match-grid.tsx
@@ -51,7 +51,6 @@ function MatchGridHeader({ count }: { count?: number }) {
 function MatchCard({ match }: { match: MatchSummary }) {
   const backgroundUrl = match.leftDishImageUrl || match.rightDishImageUrl;
   const rating = Math.max(match.leftScore, match.rightScore);
-  const scoreLabel = `${formatScore(match.leftScore)} vs ${formatScore(match.rightScore)}`;
 
   return (
     <a
@@ -82,9 +81,8 @@ function MatchCard({ match }: { match: MatchSummary }) {
       <div className="absolute inset-0 flex flex-col justify-end p-4 opacity-0 transition group-hover:opacity-100">
         <div className="flex items-center gap-1 text-xs font-semibold text-primary">
           <Star aria-hidden className="h-3.5 w-3.5" />
-          {formatScore(rating)}
+          Top Score {formatScore(rating)}
         </div>
-        <p className="mt-1 text-sm font-semibold text-white">{scoreLabel}</p>
         <p className="text-xs text-white/60">{match.dayKey}</p>
       </div>
     </a>

--- a/src/widgets/home/match-grid/match-grid.tsx
+++ b/src/widgets/home/match-grid/match-grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ArrowRight, Grid3x3, Star } from "lucide-react";
 import type { MatchFeed, MatchSummary } from "@/entities/match/model/types";
 import { ANALYTICS_EVENTS } from "@/shared/analytics/events";
 import { trackEvent } from "@/shared/analytics/track-event";
@@ -8,7 +9,6 @@ import { EmptyState } from "@/shared/ui/empty-state";
 import { ErrorState } from "@/shared/ui/error-state";
 import { Pill } from "@/shared/ui/pill";
 import { RestrictedState } from "@/shared/ui/restricted-state";
-import { ArrowRight, Grid3x3, Star } from "lucide-react";
 
 type MatchGridProps = {
   matchFeed: MatchFeed | null;
@@ -33,7 +33,7 @@ function MatchGridHeader({ count }: { count?: number }) {
         <div>
           <h2 className="text-2xl font-bold leading-tight text-white">Fresh Out the Oven</h2>
           {typeof count === "number" ? (
-            <p className="text-sm text-white/60">최신 매치 {count}개</p>
+            <p className="text-sm text-white/60">랭킹 하이라이트 {count}개</p>
           ) : null}
         </div>
       </div>
@@ -56,7 +56,7 @@ function MatchCard({ match }: { match: MatchSummary }) {
   return (
     <a
       className="group relative aspect-square overflow-hidden rounded-2xl border border-white/5 bg-card"
-      href={`/matches/${match.id}`}
+      href={`/ranking/${match.dayKey}`}
       onClick={() =>
         trackEvent(ANALYTICS_EVENTS.MATCH_VIEW, {
           screen: "home",
@@ -97,7 +97,7 @@ export default function MatchGrid({ matchFeed, isError, isRestricted }: MatchGri
       <section className="flex flex-col gap-6">
         <MatchGridHeader />
         <div className="mt-4">
-          <RestrictedState title="매치 제한" description="현재 매치를 볼 수 없습니다." />
+          <RestrictedState title="랭킹 제한" description="현재 랭킹 하이라이트를 볼 수 없습니다." />
         </div>
       </section>
     );
@@ -108,7 +108,7 @@ export default function MatchGrid({ matchFeed, isError, isRestricted }: MatchGri
       <section className="flex flex-col gap-6">
         <MatchGridHeader />
         <div className="mt-4">
-          <ErrorState title="매치 오류" description="잠시 후 다시 시도해주세요." />
+          <ErrorState title="랭킹 오류" description="잠시 후 다시 시도해주세요." />
         </div>
       </section>
     );
@@ -119,7 +119,10 @@ export default function MatchGrid({ matchFeed, isError, isRestricted }: MatchGri
       <section className="flex flex-col gap-6">
         <MatchGridHeader />
         <div className="mt-4">
-          <EmptyState title="매치가 없습니다" description="오늘의 매치가 아직 없습니다." />
+          <EmptyState
+            title="랭킹 하이라이트가 없습니다"
+            description="오늘의 랭킹 데이터가 아직 준비되지 않았습니다."
+          />
         </div>
       </section>
     );

--- a/src/widgets/home/match-grid/match-grid.tsx
+++ b/src/widgets/home/match-grid/match-grid.tsx
@@ -58,11 +58,11 @@ function MatchCard({ match }: { match: MatchSummary }) {
       className="group relative aspect-square overflow-hidden rounded-2xl border border-white/5 bg-card"
       href={`/ranking/${match.dayKey}`}
       onClick={() =>
-        trackEvent(ANALYTICS_EVENTS.MATCH_VIEW, {
+        trackEvent(ANALYTICS_EVENTS.RANKING_ITEM_CLICKED, {
           screen: "home",
-          matchId: match.id,
           dayKey: match.dayKey,
-          isPractice: match.isPractice,
+          dishId: match.id,
+          source: "home_match_grid",
         })
       }
     >

--- a/src/widgets/my-kitchen/model/kitchen-stats.test.ts
+++ b/src/widgets/my-kitchen/model/kitchen-stats.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { MatchSummary } from "@/entities/match/model/types";
+import { computeKitchenStats } from "./kitchen-stats";
+
+function match(args: Partial<MatchSummary> = {}): MatchSummary {
+  return {
+    id: args.id ?? "match-1",
+    dayKey: args.dayKey ?? "2026-03-04",
+    leftDishImageUrl: args.leftDishImageUrl ?? "https://example.com/left.jpg",
+    rightDishImageUrl: args.rightDishImageUrl ?? "https://example.com/right.jpg",
+    leftScore: args.leftScore ?? 9.0,
+    rightScore: args.rightScore ?? 8.0,
+    isPractice: args.isPractice ?? false,
+  };
+}
+
+describe("computeKitchenStats", () => {
+  it("returns null stats when no recent items", () => {
+    expect(computeKitchenStats(3, [])).toEqual({
+      dishes: 3,
+      winRate: null,
+      streak: null,
+    });
+  });
+
+  it("computes win rate and streak from decisive rows", () => {
+    const result = computeKitchenStats(5, [
+      match({ id: "m1", leftScore: 9.2, rightScore: 8.5 }),
+      match({ id: "m2", leftScore: 8.9, rightScore: 8.3 }),
+      match({ id: "m3", leftScore: 8.0, rightScore: 8.4 }),
+    ]);
+
+    expect(result).toEqual({
+      dishes: 5,
+      winRate: 67,
+      streak: 2,
+    });
+  });
+
+  it("returns null win metrics when all rows are ties", () => {
+    const result = computeKitchenStats(2, [
+      match({ id: "m1", leftScore: 8.8, rightScore: 8.8 }),
+      match({ id: "m2", leftScore: 9.1, rightScore: 9.1 }),
+    ]);
+
+    expect(result).toEqual({
+      dishes: 2,
+      winRate: null,
+      streak: null,
+    });
+  });
+});

--- a/src/widgets/my-kitchen/model/kitchen-stats.test.ts
+++ b/src/widgets/my-kitchen/model/kitchen-stats.test.ts
@@ -37,6 +37,21 @@ describe("computeKitchenStats", () => {
     });
   });
 
+  it("ignores ties in win rate and does not break winning streak", () => {
+    const result = computeKitchenStats(4, [
+      match({ id: "m1", leftScore: 9.2, rightScore: 8.5 }),
+      match({ id: "m2", leftScore: 8.9, rightScore: 8.9 }),
+      match({ id: "m3", leftScore: 8.8, rightScore: 8.1 }),
+      match({ id: "m4", leftScore: 8.2, rightScore: 8.7 }),
+    ]);
+
+    expect(result).toEqual({
+      dishes: 4,
+      winRate: 67,
+      streak: 2,
+    });
+  });
+
   it("returns null win metrics when all rows are ties", () => {
     const result = computeKitchenStats(2, [
       match({ id: "m1", leftScore: 8.8, rightScore: 8.8 }),

--- a/src/widgets/my-kitchen/model/kitchen-stats.ts
+++ b/src/widgets/my-kitchen/model/kitchen-stats.ts
@@ -7,7 +7,7 @@ type KitchenStats = {
 };
 
 function isWinMatch(match: MatchSummary) {
-  // 배틀 규칙상 동점은 발생하지 않는다.
+  // 동점(랭킹 스냅샷) 데이터는 별도 처리하고, 승패 판정은 결정적 결과만 계산한다.
   return match.leftScore > match.rightScore;
 }
 
@@ -16,11 +16,19 @@ function computeKitchenStats(dishes: number, recentMatches: MatchSummary[]): Kit
     return { dishes, winRate: null, streak: null };
   }
 
-  const wins = recentMatches.filter(isWinMatch).length;
-  const winRate = Math.round((wins / recentMatches.length) * 100);
+  const decisiveMatches = recentMatches.filter((match) => match.leftScore !== match.rightScore);
+  if (decisiveMatches.length === 0) {
+    return { dishes, winRate: null, streak: null };
+  }
+
+  const wins = decisiveMatches.filter(isWinMatch).length;
+  const winRate = Math.round((wins / decisiveMatches.length) * 100);
 
   let streak = 0;
   for (const match of recentMatches) {
+    if (match.leftScore === match.rightScore) {
+      continue;
+    }
     if (isWinMatch(match)) {
       streak += 1;
       continue;

--- a/src/widgets/my-kitchen/ui/recent-matches-panel.test.tsx
+++ b/src/widgets/my-kitchen/ui/recent-matches-panel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RecentMatchesPanel } from "./recent-matches-panel";
+
+describe("RecentMatchesPanel", () => {
+  it("routes recent cards to ranking day pages", () => {
+    render(
+      <RecentMatchesPanel
+        matches={[
+          {
+            id: "match-1",
+            dayKey: "2026-02-22",
+            leftDishImageUrl: "https://example.com/a.jpg",
+            rightDishImageUrl: "https://example.com/b.jpg",
+            leftScore: 9.1,
+            rightScore: 8.4,
+            isPractice: false,
+          },
+        ]}
+        isPending={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText("Recent Ranking Days")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /vs\./i })).toHaveAttribute(
+      "href",
+      "/ranking/2026-02-22",
+    );
+  });
+
+  it("renders ranking-oriented empty copy", () => {
+    render(<RecentMatchesPanel matches={[]} isPending={false} isError={false} />);
+
+    expect(screen.getByText("최근 랭킹 기록이 없습니다.")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/my-kitchen/ui/recent-matches-panel.test.tsx
+++ b/src/widgets/my-kitchen/ui/recent-matches-panel.test.tsx
@@ -23,10 +23,12 @@ describe("RecentMatchesPanel", () => {
     );
 
     expect(screen.getByText("Recent Ranking Days")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /vs\./i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Ranking Snapshot/i })).toHaveAttribute(
       "href",
       "/ranking/2026-02-22",
     );
+    expect(screen.getByText("Top Score")).toBeInTheDocument();
+    expect(screen.getByText("9.1")).toBeInTheDocument();
   });
 
   it("renders ranking-oriented empty copy", () => {

--- a/src/widgets/my-kitchen/ui/recent-matches-panel.tsx
+++ b/src/widgets/my-kitchen/ui/recent-matches-panel.tsx
@@ -22,8 +22,8 @@ function RecentMatchesPanel({ matches, isPending, isError }: RecentMatchesPanelP
     >
       <aside>
         <SectionHeading
-          title="Recent Matches"
-          description="최근 매치 결과와 점수 변동"
+          title="Recent Ranking Days"
+          description="최근 랭킹 기준일과 점수 변동"
           className="items-start"
         />
 
@@ -35,13 +35,16 @@ function RecentMatchesPanel({ matches, isPending, isError }: RecentMatchesPanelP
           </div>
         ) : isError ? (
           <div className="mt-4">
-            <ErrorState title="Recent Matches 오류" description="매치를 불러오지 못했습니다." />
+            <ErrorState
+              title="Recent Ranking 오류"
+              description="랭킹 요약을 불러오지 못했습니다."
+            />
           </div>
         ) : matches.length === 0 ? (
           <div className="mt-4">
             <EmptyState
-              title="최근 매치가 없습니다."
-              description="매치가 생성되면 여기에 표시됩니다."
+              title="최근 랭킹 기록이 없습니다."
+              description="랭킹 데이터가 생성되면 여기에 표시됩니다."
             />
           </div>
         ) : (
@@ -57,7 +60,7 @@ function RecentMatchesPanel({ matches, isPending, isError }: RecentMatchesPanelP
                 <li key={match.id}>
                   <Surface asChild tone="soft" radius="lg" interactive="borderAndBackground">
                     <Link
-                      href={`/matches/${match.id}`}
+                      href={`/ranking/${match.dayKey}`}
                       className="flex items-center justify-between gap-3 px-3 py-2"
                     >
                       <div className="flex items-center gap-3">

--- a/src/widgets/my-kitchen/ui/recent-matches-panel.tsx
+++ b/src/widgets/my-kitchen/ui/recent-matches-panel.tsx
@@ -50,12 +50,8 @@ function RecentMatchesPanel({ matches, isPending, isError }: RecentMatchesPanelP
         ) : (
           <ul className="mt-4 space-y-3">
             {matches.map((match) => {
-              const isWin = match.leftScore > match.rightScore;
-              const pointDiff = Math.round(Math.abs(match.leftScore - match.rightScore) * 10);
-              const pointLabel = `${isWin ? "+" : "-"}${pointDiff}`;
-              const matchResult = isWin ? "WIN" : "LOSS";
-              const resultToneClass = isWin ? "text-emerald-300" : "text-rose-300";
-              const opponentLabel = "Mock Opponent";
+              const topScore = Math.max(match.leftScore, match.rightScore);
+              const topScoreLabel = Number.isFinite(topScore) ? topScore.toFixed(1) : "-";
               return (
                 <li key={match.id}>
                   <Surface asChild tone="soft" radius="lg" interactive="borderAndBackground">
@@ -69,16 +65,18 @@ function RecentMatchesPanel({ matches, isPending, isError }: RecentMatchesPanelP
                           radius="full"
                           className="flex h-9 w-9 items-center justify-center text-xs font-bold text-white/80"
                         >
-                          MO
+                          RK
                         </Surface>
                         <div>
-                          <p className="text-sm font-semibold text-white">vs. {opponentLabel}</p>
+                          <p className="text-sm font-semibold text-white">Ranking Snapshot</p>
                           <p className="text-xs text-white/60">{match.dayKey}</p>
                         </div>
                       </div>
                       <div className="text-right">
-                        <p className={`text-xs font-bold ${resultToneClass}`}>{matchResult}</p>
-                        <p className={`text-sm font-semibold ${resultToneClass}`}>{pointLabel}</p>
+                        <p className="text-xs font-bold uppercase tracking-[0.12em] text-primary/80">
+                          Top Score
+                        </p>
+                        <p className="text-sm font-semibold text-primary">{topScoreLabel}</p>
                       </div>
                     </Link>
                   </Surface>


### PR DESCRIPTION
## 개요

- 변경 목적:
  - 기존 점수 기반 구조를 기준으로 남아 있던 매치 중심 표면(`/matches/:id`, `MATCH_VIEW`, VS 카드 표현)을 랭킹 중심으로 정리한다.
  - 랭킹 API(top/archive)와 검색 rank 계산 경로의 정렬/tie-break/봇 포함 정책을 일관된 단일 정책으로 통일한다.
  - pre-PR 리뷰에서 발견된 이벤트 payload 누락 및 Recent Ranking UI 오해 요소를 함께 수정해 출시 품질을 맞춘다.
- 사용자 영향:
  - 홈/내 주방에서 더 이상 매치 상세 경로로 이동하지 않고 일관되게 `/ranking/:dayKey`로 이동한다.
  - 홈 `Top Rated`/`Fresh Out the Oven` 카드가 단일 랭킹 카드 표현으로 렌더링된다.
  - 봇만 존재하는 날에도 오늘의 랭킹이 기본 노출되며, 필요 시 `includeBots=false`로만 제외 조회한다.

## 변경 사항

- [x] 랭킹 정렬/tie-break 공통 정책(`totalScore > themeFit > execution > analyzedAt > id`) 모듈화 및 top/archive/search 경로 통일
- [x] 공개 랭킹 봇 정책을 기본 허용으로 전환하고 `includeBots=false` 예외 경로 유지
- [x] 홈/내 주방의 `/matches/:id` 링크 제거 후 `/ranking/:dayKey`로 통일
- [x] `mock match feed`/`MATCH_VIEW` 의존 제거 및 랭킹 이벤트(`RANKING_ITEM_CLICKED`) 중심으로 정리
- [x] 홈 `오늘의 랭킹 — Top Rated` 단일 랭킹 카드화 및 `RankingEntry` left/right 파생 필드 제거
- [x] 홈 `Fresh Out the Oven` 카드의 VS 표기 제거 및 단일 점수 하이라이트 표현 전환
- [x] pre-PR 리뷰 보정:
  - `highlights` 클릭 이벤트 payload에 `dishId` 추가
  - `Recent Ranking Days` 패널을 ranking snapshot + top score 표기로 정리
  - 동점 데이터에서 `winRate/streak`를 null 처리하도록 `kitchen-stats` 보강 + 테스트 추가

## 테스트

- [x] `pnpm lint` — PASS (Checked 289 files, no fixes) (2026-03-04)
- [x] `pnpm typecheck` — PASS (2026-03-04)
- [x] `pnpm test` — PASS (74 files, 294 tests) (2026-03-04)
- [x] `pnpm audit --prod` — FAIL (high 2, moderate 3; 잔여 리스크로 분리 관리)

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
    participant Home as Home/MyKitchen UI
    participant RankingApi as /api/ranking/:dayKey
    participant RankingDomain as listRankingTop/listRankingArchive
    participant Policy as ranking-policy
    participant DB as dish_day_score

    Home->>RankingApi: count/view/archive/includeBots 요청
    RankingApi->>RankingDomain: 정규화된 파라미터 전달
    RankingDomain->>Policy: 공통 정렬/필터 정책 조회
    RankingDomain->>DB: top/archive/search 조회
    DB-->>RankingDomain: ranked rows
    RankingDomain-->>RankingApi: RankingTop/ArchiveResponse
    RankingApi-->>Home: 랭킹 카드/리스트 렌더링 데이터
```

## 관련 문서

- Spec: `docs/features/F016-daily-ranking-system/spec.md`
- Tasks: `docs/features/F016-daily-ranking-system/tasks.md`
- Decisions: `docs/features/F016-daily-ranking-system/decisions.md`
- Issue: `#30`


Closes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 랭킹에서 봇 생성 항목을 포함할지 선택할 수 있는 옵션 추가.

* **개선 사항**
  * 하이라이트 카드 레이아웃 단순화: 단일 이미지와 한눈에 보이는 점수로 변경.
  * 홈·최근 활동 UI를 랭킹 중심 용어와 링크로 전환.
  * 주방 통계의 승률 계산을 비긴 경기에서 제외하도록 개선.
  * 랭킹 클릭 이벤트에 dishId가 포함되어 분석 정확성 향상.

* **테스트**
  * 분석 이벤트 유효성 검사 및 관련 동작에 대한 단위/통합 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->